### PR TITLE
:sparkles: add ros2_control dependencies

### DIFF
--- a/.docker/work/Dockerfile
+++ b/.docker/work/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update && apt-get install -y \
     clang-format \
     ros-${ROS_DISTRO}-ament-clang-format \
     ros-${ROS_DISTRO}-ament-cmake-clang-format \
+    ros-${ROS_DISTRO}-ros2-control \
+    ros-${ROS_DISTRO}-ros2-controllers \
     && rm -rf /var/lib/apt/lists/*
 
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> /home/ubuntu/.bashrc


### PR DESCRIPTION
ROS2 controlがdockerコンテナに入ってなかったので、入れました。
コンテナの起動までは確認済みです。