### PR TITLE
Add EditorConfig

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,41 +3,41 @@
   "service": "work",
   "workspaceFolder": "/home/ubuntu/ros_ws/src/pkg",
   "customizations": {
-      "vscode": {
-          "extensions": [
-              "ms-iot.vscode-ros",
-              "ms-python.python",
-              "ms-python.autopep8",
-              "ms-vscode.cpptools",
-              "ms-vscode.cmake-tools",
-              "redhat.vscode-xml",
-              "redhat.vscode-yaml"
-          ],
-          "settings": {
-              "editor.formatOnSave": true,
-              "[xml]": {
-                  "editor.defaultFormatter": "redhat.vscode-xml"
-              },
-              "[yaml]": {
-                  "editor.defaultFormatter": "redhat.vscode-yaml"
-              },
-              "[python]": {
-                  "editor.defaultFormatter": "ms-python.autopep8"
-              },
-              "python.analysis.inlayHints.callArgumentNames": "partial",
-              "python.analysis.inlayHints.functionReturnTypes": true,
-              "python.analysis.inlayHints.variableTypes": true,
-              "python.analysis.inlayHints.pytestParameters": true,
-              "[cpp]": {
-                  "editor.defaultFormatter": "ms-vscode.cpptools"
-              },
-              "C_Cpp.inlayHints.autoDeclarationTypes.enabled": true,
-              "C_Cpp.inlayHints.autoFunctionReturnTypes.enabled": true,
-              "C_Cpp.inlayHints.variableTypes.enabled": true,
-              "[ros.msg]": {
-                  "editor.defaultFormatter": "ms-iot.vscode-ros"
-              }
-          }
+    "vscode": {
+      "extensions": [
+        "ms-iot.vscode-ros",
+        "ms-python.python",
+        "ms-python.autopep8",
+        "ms-vscode.cpptools",
+        "ms-vscode.cmake-tools",
+        "redhat.vscode-xml",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "[xml]": {
+          "editor.defaultFormatter": "redhat.vscode-xml"
+        },
+        "[yaml]": {
+          "editor.defaultFormatter": "redhat.vscode-yaml"
+        },
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.autopep8"
+        },
+        "python.analysis.inlayHints.callArgumentNames": "partial",
+        "python.analysis.inlayHints.functionReturnTypes": true,
+        "python.analysis.inlayHints.variableTypes": true,
+        "python.analysis.inlayHints.pytestParameters": true,
+        "[cpp]": {
+          "editor.defaultFormatter": "ms-vscode.cpptools"
+        },
+        "C_Cpp.inlayHints.autoDeclarationTypes.enabled": true,
+        "C_Cpp.inlayHints.autoFunctionReturnTypes.enabled": true,
+        "C_Cpp.inlayHints.variableTypes.enabled": true,
+        "[ros.msg]": {
+          "editor.defaultFormatter": "ms-iot.vscode-ros"
+        }
       }
+    }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig is awesome: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*.{cpp,hpp}]
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[*.{xml,xacro}]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.json]
+indent_size = 2


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org)というツールの設定ファイル`.editorconfig`を追加したので、VSCodeなどのエディタで拡張機能を入れれば個人の設定に関係なく適切なインデント幅などが設定されるようになります。