### PR TITLE
refactor(hardware): use `thruster_direct` class for each thrusters

### DIFF
--- a/include/sinsei_umiusi_control/hardware/thruster_direct.hpp
+++ b/include/sinsei_umiusi_control/hardware/thruster_direct.hpp
@@ -15,9 +15,9 @@ namespace sinsei_umiusi_control::hardware {
 
 class ThrusterDirect : public hardware_interface::ActuatorInterface {
   private:
-    std::array<suc::cmd::thruster::Enabled, 4> thruster_enabled;
-    std::array<suc::cmd::thruster::Angle, 4> thruster_angle;
-    std::array<suc::cmd::thruster::Thrust, 4> thruster_thrust;
+    suc::cmd::thruster::Enabled enabled;
+    suc::cmd::thruster::Angle angle;
+    suc::cmd::thruster::Thrust thrust;
 
   public:
     RCLCPP_SHARED_PTR_DEFINITIONS(ThrusterDirect)

--- a/urdf/sinsei_umiusi_control/thruster_direct.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/thruster_direct.urdf.xacro
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
   <xacro:macro name="thruster_direct">
-    <ros2_control name="thruster_direct" type="actuator">
-      <hardware>
-        <plugin>sinsei_umiusi_control/hardware/ThrusterDirect</plugin>
-      </hardware>
-
-      <xacro:macro name="thruster_direct" params="id">
-        <xacro:property name="thruster_name" value="thruster_direct${id}" />
-
+    <xacro:macro name="thruster_direct" params="id">
+      <xacro:property name="thruster_name" value="thruster_direct${id}" />
+      <ros2_control name="${thruster_name}" type="actuator">
+        <hardware>
+          <plugin>sinsei_umiusi_control/hardware/ThrusterDirect</plugin>
+        </hardware>
         <gpio name="${thruster_name}/servo_direct">
           <command_interface name="thruster_direct/enabled_raw" />
           <command_interface name="thruster_direct/angle_raw" />
@@ -18,12 +16,12 @@
           <command_interface name="thruster_direct/enabled_raw" />
           <command_interface name="thruster_direct/thrust_raw" />
         </gpio>
-      </xacro:macro>
+      </ros2_control>
+    </xacro:macro>
 
-      <xacro:thruster_direct id="1" />
-      <xacro:thruster_direct id="2" />
-      <xacro:thruster_direct id="3" />
-      <xacro:thruster_direct id="4" />
-    </ros2_control>
+    <xacro:thruster_direct id="1" />
+    <xacro:thruster_direct id="2" />
+    <xacro:thruster_direct id="3" />
+    <xacro:thruster_direct id="4" />
   </xacro:macro>
 </robot>


### PR DESCRIPTION
一つの`thruster_direct`インスタンスで4つのスラスターを制御するのではなく、各スラスター用にインスタンスを用意する方法に変更