### PR TITLE
Export Command/State-interfaces and setup controllers

### DIFF
--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -4,15 +4,34 @@ controller_manager:
 
 gate_controller:
   ros__parameters:
-    type: sinsei_umiusi_control/GateController
-    upate_rate: 50 # Hz
+    type: sinsei_umiusi_control/controller/GateController
+    update_rate: 50 # Hz
 
 app_controller:
   ros__parameters:
-    type: sinsei_umiusi_control/AppController
+    type: sinsei_umiusi_control/controller/AppController
     update_rate: 50 # Hz
 
-thruster_controller:
+thruster_controller1:
   ros__parameters:
-    type: sinsei_umiusi_control/ThrusterController
+    type: sinsei_umiusi_control/controller/ThrusterController
     update_rate: 50 # Hz
+    id: 1
+
+thruster_controller2:
+  ros__parameters:
+    type: sinsei_umiusi_control/controller/ThrusterController
+    update_rate: 50 # Hz
+    id: 2
+
+thruster_controller3:
+  ros__parameters:
+    type: sinsei_umiusi_control/controller/ThrusterController
+    update_rate: 50 # Hz
+    id: 3
+
+thruster_controller4:
+  ros__parameters:
+    type: sinsei_umiusi_control/controller/ThrusterController
+    update_rate: 50 # Hz
+    id: 4

--- a/include/sinsei_umiusi_control/cmd/app.hpp
+++ b/include/sinsei_umiusi_control/cmd/app.hpp
@@ -4,14 +4,14 @@
 namespace sinsei_umiusi_control::cmd::app {
 
 struct Orientation {
-    float x;
-    float y;
-    float z;
+    double x;
+    double y;
+    double z;
 };
 struct Velocity {
-    float x;
-    float y;
-    float z;
+    double x;
+    double y;
+    double z;
 };
 
 }  // namespace sinsei_umiusi_control::cmd::app

--- a/include/sinsei_umiusi_control/cmd/thruster.hpp
+++ b/include/sinsei_umiusi_control/cmd/thruster.hpp
@@ -5,7 +5,7 @@
 namespace sinsei_umiusi_control::cmd::thruster {
 
 struct Enabled {
-    double value;
+    bool value;
 };
 struct Angle {
     double value;

--- a/include/sinsei_umiusi_control/cmd/thruster.hpp
+++ b/include/sinsei_umiusi_control/cmd/thruster.hpp
@@ -5,13 +5,13 @@
 namespace sinsei_umiusi_control::cmd::thruster {
 
 struct Enabled {
-    bool value;
+    double value;
 };
 struct Angle {
-    int8_t value;
+    double value;
 };
 struct Thrust {
-    uint8_t value;
+    double value;
 };
 
 }  // namespace sinsei_umiusi_control::cmd::thruster

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -23,6 +23,7 @@
 #include "sinsei_umiusi_control/state/raspi_camera.hpp"
 #include "sinsei_umiusi_control/state/thruster.hpp"
 #include "sinsei_umiusi_control/state/usb_camera.hpp"
+#include "std_msgs/msg/bool.hpp"
 
 namespace suc = sinsei_umiusi_control;
 
@@ -30,6 +31,9 @@ namespace sinsei_umiusi_control::controller {
 
 class GateController : public controller_interface::ControllerInterface {
   private:
+    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    bool indicator_led_enabled_ref;
+
     // Command interfaces (out)
     std::unique_ptr<hardware_interface::LoanedCommandInterface> main_power_enabled;
     std::unique_ptr<hardware_interface::LoanedCommandInterface> led_tape_color;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -32,7 +32,7 @@ namespace sinsei_umiusi_control::controller {
 class GateController : public controller_interface::ControllerInterface {
   private:
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
-    bool indicator_led_enabled_ref;
+    cmd::indicator_led::Enabled indicator_led_enabled_ref;
 
     // Command interfaces (out)
     std::unique_ptr<hardware_interface::LoanedCommandInterface> main_power_enabled;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -32,6 +32,8 @@ namespace sinsei_umiusi_control::controller {
 class GateController : public controller_interface::ControllerInterface {
   private:
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr indicator_led_enabled_subscriber;
+
     cmd::indicator_led::Enabled indicator_led_enabled_ref;
 
     // Command interfaces (out)

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -35,6 +35,9 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::ServoCurrent servo_current;
     suc::state::thruster::Rpm rpm;
 
+    // Thruster ID (1~4)
+    int64_t id;
+
   public:
     ThrusterController() = default;
 

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -36,7 +36,7 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::Rpm rpm;
 
     // Thruster ID (1~4)
-    int8_t id;
+    uint8_t id;
 
   public:
     ThrusterController() = default;

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -36,7 +36,7 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::Rpm rpm;
 
     // Thruster ID (1~4)
-    int64_t id;
+    int8_t id;
 
   public:
     ThrusterController() = default;

--- a/include/sinsei_umiusi_control/hardware/can.hpp
+++ b/include/sinsei_umiusi_control/hardware/can.hpp
@@ -22,24 +22,21 @@ class Can : public hardware_interface::SystemInterface {
     std::array<suc::cmd::thruster::Enabled, 4> thruster_enabled;
     std::array<suc::cmd::thruster::Angle, 4> thruster_angle;
     std::array<suc::cmd::thruster::Thrust, 4> thruster_thrust;
-
     suc::cmd::main_power::Enabled main_power_enabled;
     suc::cmd::led_tape::Color led_tape_color;
 
     std::array<suc::state::thruster::ServoCurrent, 4> thruster_servo_current;
     std::array<suc::state::thruster::Rpm, 4> thruster_rpm;
+    suc::state::main_power::BatteryCurrent battery_current;
+    suc::state::main_power::BatteryVoltage battery_voltage;
+    suc::state::main_power::Temperature temperature;
+    suc::state::main_power::WaterLeaked water_leaked;
 
   public:
     RCLCPP_SHARED_PTR_DEFINITIONS(Can)
 
     Can() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/hardware/headlights.hpp
+++ b/include/sinsei_umiusi_control/hardware/headlights.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "rclcpp/macros.hpp"
 #include "sinsei_umiusi_control/cmd/headlights.hpp"
 
@@ -13,7 +13,7 @@ namespace suc = sinsei_umiusi_control;
 
 namespace sinsei_umiusi_control::hardware {
 
-class Headlights : public hardware_interface::ActuatorInterface {
+class Headlights : public hardware_interface::SystemInterface {
   private:
     suc::cmd::headlights::HighBeamEnabled high_beam_enabled;
     suc::cmd::headlights::LowBeamEnabled low_beam_enabled;
@@ -24,12 +24,6 @@ class Headlights : public hardware_interface::ActuatorInterface {
 
     Headlights() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/hardware/imu.hpp
+++ b/include/sinsei_umiusi_control/hardware/imu.hpp
@@ -24,10 +24,6 @@ class Imu : public hardware_interface::SensorInterface {
 
     Imu() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
 };

--- a/include/sinsei_umiusi_control/hardware/indicator_led.hpp
+++ b/include/sinsei_umiusi_control/hardware/indicator_led.hpp
@@ -15,6 +15,7 @@ namespace sinsei_umiusi_control::hardware {
 
 class IndicatorLed : public hardware_interface::SystemInterface {
   private:
+    // TODO: 不要なためコメントアウト中。将来的に削除する。
     // suc::cmd::indicator_led::Enabled enabled;
 
   public:

--- a/include/sinsei_umiusi_control/hardware/indicator_led.hpp
+++ b/include/sinsei_umiusi_control/hardware/indicator_led.hpp
@@ -15,7 +15,7 @@ namespace sinsei_umiusi_control::hardware {
 
 class IndicatorLed : public hardware_interface::SystemInterface {
   private:
-    suc::cmd::indicator_led::Enabled enabled;
+    // suc::cmd::indicator_led::Enabled enabled;
 
   public:
     RCLCPP_SHARED_PTR_DEFINITIONS(IndicatorLed)

--- a/include/sinsei_umiusi_control/hardware/indicator_led.hpp
+++ b/include/sinsei_umiusi_control/hardware/indicator_led.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "rclcpp/macros.hpp"
 #include "sinsei_umiusi_control/cmd/indicator_led.hpp"
 
@@ -13,7 +13,7 @@ namespace suc = sinsei_umiusi_control;
 
 namespace sinsei_umiusi_control::hardware {
 
-class IndicatorLed : public hardware_interface::ActuatorInterface {
+class IndicatorLed : public hardware_interface::SystemInterface {
   private:
     suc::cmd::indicator_led::Enabled enabled;
 
@@ -22,12 +22,6 @@ class IndicatorLed : public hardware_interface::ActuatorInterface {
 
     IndicatorLed() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/hardware/raspi_camera.hpp
+++ b/include/sinsei_umiusi_control/hardware/raspi_camera.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "rclcpp/macros.hpp"
 #include "sinsei_umiusi_control/cmd/raspi_camera.hpp"
 #include "sinsei_umiusi_control/state/raspi_camera.hpp"
@@ -14,7 +14,7 @@ namespace suc = sinsei_umiusi_control;
 
 namespace sinsei_umiusi_control::hardware {
 
-class RaspiCamera : public hardware_interface::ActuatorInterface {
+class RaspiCamera : public hardware_interface::SystemInterface {
   private:
     suc::cmd::raspi_camera::Config config;
     suc::state::raspi_camera::Image image;
@@ -24,12 +24,6 @@ class RaspiCamera : public hardware_interface::ActuatorInterface {
 
     RaspiCamera() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/hardware/thruster_direct.hpp
+++ b/include/sinsei_umiusi_control/hardware/thruster_direct.hpp
@@ -24,12 +24,6 @@ class ThrusterDirect : public hardware_interface::ActuatorInterface {
 
     ThrusterDirect() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/hardware/usb_camera.hpp
+++ b/include/sinsei_umiusi_control/hardware/usb_camera.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "hardware_interface/actuator_interface.hpp"
+#include "hardware_interface/system_interface.hpp"
 #include "rclcpp/macros.hpp"
 #include "sinsei_umiusi_control/cmd/usb_camera.hpp"
 #include "sinsei_umiusi_control/state/usb_camera.hpp"
@@ -14,7 +14,7 @@ namespace suc = sinsei_umiusi_control;
 
 namespace sinsei_umiusi_control::hardware {
 
-class UsbCamera : public hardware_interface::ActuatorInterface {
+class UsbCamera : public hardware_interface::SystemInterface {
   private:
     suc::cmd::usb_camera::Config config;
     suc::state::usb_camera::Image image;
@@ -24,12 +24,6 @@ class UsbCamera : public hardware_interface::ActuatorInterface {
 
     UsbCamera() = default;
 
-    auto on_init(const hardware_interface::HardwareInfo & info)
-        -> hardware_interface::CallbackReturn override;
-    auto on_export_state_interfaces()
-        -> std::vector<hardware_interface::StateInterface::ConstSharedPtr> override;
-    auto on_export_command_interfaces()
-        -> std::vector<hardware_interface::CommandInterface::SharedPtr> override;
     auto read(const rclcpp::Time & time, const rclcpp::Duration & period)
         -> hardware_interface::return_type override;
     auto write(const rclcpp::Time & time, const rclcpp::Duration & period)

--- a/include/sinsei_umiusi_control/state/thruster.hpp
+++ b/include/sinsei_umiusi_control/state/thruster.hpp
@@ -4,10 +4,10 @@
 namespace sinsei_umiusi_control::state::thruster {
 
 struct ServoCurrent {
-    float value;
+    double value;
 };
 struct Rpm {
-    float value;
+    double value;
 };
 
 }  // namespace sinsei_umiusi_control::state::thruster

--- a/launch/launch.xml
+++ b/launch/launch.xml
@@ -29,7 +29,19 @@
 
   <node pkg="controller_manager"
     exec="spawner"
-    args="thruster_controller --param-file $(var robot_controllers_path)" />
+    args="thruster_controller1 --param-file $(var robot_controllers_path)" />
+
+  <node pkg="controller_manager"
+    exec="spawner"
+    args="thruster_controller2 --param-file $(var robot_controllers_path)" />
+
+  <node pkg="controller_manager"
+    exec="spawner"
+    args="thruster_controller3 --param-file $(var robot_controllers_path)" />
+
+  <node pkg="controller_manager"
+    exec="spawner"
+    args="thruster_controller4 --param-file $(var robot_controllers_path)" />
 
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
     <param name="robot_description" value="$(var robot_description)" />

--- a/plugin/umiusi_controller_plugin.xml
+++ b/plugin/umiusi_controller_plugin.xml
@@ -18,39 +18,12 @@
     </description>
   </class>
   <class
-    name="sinsei_umiusi_control/controller/ThrusterController1"
+    name="sinsei_umiusi_control/controller/ThrusterController"
     type="sinsei_umiusi_control::controller::ThrusterController"
     base_class_type="controller_interface::ChainableControllerInterface"
   >
     <description>
-      Thruster controller 1
-    </description>
-  </class>
-  <class
-    name="sinsei_umiusi_control/controller/ThrusterController2"
-    type="sinsei_umiusi_control::controller::ThrusterController"
-    base_class_type="controller_interface::ChainableControllerInterface"
-  >
-    <description>
-      Thruster controller 2
-    </description>
-  </class>
-  <class
-    name="sinsei_umiusi_control/controller/ThrusterController3"
-    type="sinsei_umiusi_control::controller::ThrusterController"
-    base_class_type="controller_interface::ChainableControllerInterface"
-  >
-    <description>
-      Thruster controller 3
-    </description>
-  </class>
-  <class
-    name="sinsei_umiusi_control/controller/ThrusterController4"
-    type="sinsei_umiusi_control::controller::ThrusterController"
-    base_class_type="controller_interface::ChainableControllerInterface"
-  >
-    <description>
-      Thruster controller 4
+      Thruster controller
     </description>
   </class>
 </library>

--- a/plugin/umiusi_hardware_plugin.xml
+++ b/plugin/umiusi_hardware_plugin.xml
@@ -20,7 +20,7 @@
   <class
     name="sinsei_umiusi_control/hardware/IndicatorLed"
     type="sinsei_umiusi_control::hardware::IndicatorLed"
-    base_class_type="hardware_interface::ActuatorInterface"
+    base_class_type="hardware_interface::SystemInterface"
   >
     <description>
       Interface to indicator LED for UMIUSI
@@ -38,7 +38,7 @@
   <class
     name="sinsei_umiusi_control/hardware/Headlights"
     type="sinsei_umiusi_control::hardware::Headlights"
-    base_class_type="hardware_interface::ActuatorInterface"
+    base_class_type="hardware_interface::SystemInterface"
   >
     <description>
       Interface to headlights for UMIUSI
@@ -47,7 +47,7 @@
   <class
     name="sinsei_umiusi_control/hardware/UsbCamera"
     type="sinsei_umiusi_control::hardware::UsbCamera"
-    base_class_type="hardware_interface::ActuatorInterface"
+    base_class_type="hardware_interface::SystemInterface"
   >
     <description>
       Interface to USB camera for UMIUSI
@@ -56,7 +56,7 @@
   <class
     name="sinsei_umiusi_control/hardware/RaspiCamera"
     type="sinsei_umiusi_control::hardware::RaspiCamera"
-    base_class_type="hardware_interface::ActuatorInterface"
+    base_class_type="hardware_interface::SystemInterface"
   >
     <description>
       Interface to Raspi camera for UMIUSI

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -7,14 +7,14 @@ namespace cif = controller_interface;
 
 auto succ::AppController::command_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
-        cif::interface_configuration_type::ALL,
+        cif::interface_configuration_type::INDIVIDUAL,
         {},
     };
 }
 
 auto succ::AppController::state_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
-        cif::interface_configuration_type::ALL,
+        cif::interface_configuration_type::INDIVIDUAL,
         {},
     };
 }
@@ -37,7 +37,27 @@ auto succ::AppController::on_deactivate(const rlc::State & /*previous_state*/)
 }
 
 auto succ::AppController::on_export_reference_interfaces() -> std::vector<hif::CommandInterface> {
+    this->reference_interfaces_.resize(6);
+
     auto interfaces = std::vector<hif::CommandInterface>{};
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_orientation.x"), "target_orientation.x",
+        &this->target_orientation.x));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_orientation.y"), "target_orientation.y",
+        &this->target_orientation.y));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_orientation.z"), "target_orientation.z",
+        &this->target_orientation.z));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_velocity.x"), "target_velocity.x",
+        &this->target_velocity.x));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_velocity.y"), "target_velocity.y",
+        &this->target_velocity.y));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/target_velocity.z"), "target_velocity.z",
+        &this->target_velocity.z));
     return interfaces;
 }
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -24,11 +24,12 @@ auto succ::GateController::on_init() -> cif::CallbackReturn { return cif::Callba
 auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
-    this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
-        [this](const std_msgs::msg::Bool::SharedPtr input) {
-            this->indicator_led_enabled_ref.value = input->data;
-        });
+    this->indicator_led_enabled_subscriber =
+        this->get_node()->create_subscription<std_msgs::msg::Bool>(
+            "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
+            [this](const std_msgs::msg::Bool::SharedPtr input) {
+                this->indicator_led_enabled_ref.value = input->data;
+            });
     return cif::CallbackReturn::SUCCESS;
 }
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -23,11 +23,29 @@ auto succ::GateController::on_init() -> cif::CallbackReturn { return cif::Callba
 
 auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
+    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    this->get_node()->create_subscription<std_msgs::msg::Bool>(
+        "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
+        [this](const std_msgs::msg::Bool::SharedPtr input) {
+            this->indicator_led_enabled_ref = input->data;
+        });
     return cif::CallbackReturn::SUCCESS;
 }
 
 auto succ::GateController::on_activate(const rlc::State & /*previous_state*/)
     -> cif::CallbackReturn {
+    // `CommandInterface`にアクセスしやすいよう、メンバ変数にポインタを持っておく。
+    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    auto it = std::find_if(
+        this->command_interfaces_.begin(), this->command_interfaces_.end(),
+        [&](const auto & ifc) { return ifc.get_name() == "indicator_led/indicator_led/enabled"; });
+    if (it != this->command_interfaces_.end()) {
+        this->indicator_led_enabled.reset(it.base());
+    } else {
+        RCLCPP_ERROR(
+            this->get_node()->get_logger(),
+            "Failed to find command interface: indicator_led/indicator_led/enabled");
+    }
     return cif::CallbackReturn::SUCCESS;
 }
 
@@ -39,6 +57,20 @@ auto succ::GateController::on_deactivate(const rlc::State & /*previous_state*/)
 auto succ::GateController::update(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/
     ) -> cif::return_type {
+    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    if (!this->indicator_led_enabled) {
+        RCLCPP_ERROR(
+            this->get_node()->get_logger(),
+            "Command interface not initialized: indicator_led/indicator_led/enabled");
+        return cif::return_type::ERROR;
+    }
+    auto res =
+        indicator_led_enabled->set_value(static_cast<double>(this->indicator_led_enabled_ref));
+    if (!res) {
+        RCLCPP_WARN(
+            this->get_node()->get_logger(), "Failed to set command interface value: %s",
+            indicator_led_enabled->get_name().c_str());
+    }
     return cif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -27,7 +27,7 @@ auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     this->get_node()->create_subscription<std_msgs::msg::Bool>(
         "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
-            this->indicator_led_enabled_ref = input->data;
+            this->indicator_led_enabled_ref.value = input->data;
         });
     return cif::CallbackReturn::SUCCESS;
 }
@@ -64,8 +64,8 @@ auto succ::GateController::update(
             "Command interface not initialized: indicator_led/indicator_led/enabled");
         return cif::return_type::ERROR;
     }
-    auto res =
-        indicator_led_enabled->set_value(static_cast<double>(this->indicator_led_enabled_ref));
+    auto res = indicator_led_enabled->set_value(
+        static_cast<double>(this->indicator_led_enabled_ref.value));
     if (!res) {
         RCLCPP_WARN(
             this->get_node()->get_logger(), "Failed to set command interface value: %s",

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -65,7 +65,7 @@ auto succ::GateController::update(
         return cif::return_type::ERROR;
     }
     auto res = indicator_led_enabled->set_value(
-        static_cast<double>(this->indicator_led_enabled_ref.value));
+        *reinterpret_cast<double *>(&this->indicator_led_enabled_ref));
     if (!res) {
         RCLCPP_WARN(
             this->get_node()->get_logger(), "Failed to set command interface value: %s",

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -49,11 +49,14 @@ auto succ::ThrusterController::on_export_reference_interfaces()
 
     auto interfaces = std::vector<hif::CommandInterface>{};
     interfaces.emplace_back(hif::CommandInterface(
-        this->get_node()->get_name() + std::string("/enabled"), "enabled", &this->enabled.value));
+        this->get_node()->get_name() + std::string("/enabled"), "enabled",
+        reinterpret_cast<double *>(&this->enabled)));
     interfaces.emplace_back(hif::CommandInterface(
-        this->get_node()->get_name() + std::string("/angle"), "angle", &this->angle.value));
+        this->get_node()->get_name() + std::string("/angle"), "angle",
+        reinterpret_cast<double *>(&this->angle)));
     interfaces.emplace_back(hif::CommandInterface(
-        this->get_node()->get_name() + std::string("/thrust"), "thrust", &this->thrust.value));
+        this->get_node()->get_name() + std::string("/thrust"), "thrust",
+        reinterpret_cast<double *>(&this->thrust)));
     return interfaces;
 }
 
@@ -62,9 +65,10 @@ auto succ::ThrusterController::on_export_state_interfaces() -> std::vector<hif::
 
     interfaces.emplace_back(hif::StateInterface(
         this->get_node()->get_name() + std::string("/servo_current"), "servo_current",
-        &this->servo_current.value));
+        reinterpret_cast<double *>(&this->servo_current)));
     interfaces.emplace_back(hif::StateInterface(
-        this->get_node()->get_name() + std::string("/rpm"), "rpm", &this->rpm.value));
+        this->get_node()->get_name() + std::string("/rpm"), "rpm",
+        reinterpret_cast<double *>(&this->rpm)));
     return interfaces;
 }
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -8,7 +8,7 @@ namespace cif = controller_interface;
 auto succ::ThrusterController::command_interface_configuration() const
     -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
-        cif::interface_configuration_type::ALL,
+        cif::interface_configuration_type::INDIVIDUAL,
         {},
     };
 }
@@ -16,12 +16,15 @@ auto succ::ThrusterController::command_interface_configuration() const
 auto succ::ThrusterController::state_interface_configuration() const
     -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
-        cif::interface_configuration_type::ALL,
+        cif::interface_configuration_type::INDIVIDUAL,
         {},
     };
 }
 
 auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
+    this->get_node()->declare_parameter("id", 1);
+    this->id = this->get_node()->get_parameter("id").as_int();
+    RCLCPP_INFO(get_node()->get_logger(), "Thruster ID: %ld", this->id);
     return cif::CallbackReturn::SUCCESS;
 }
 
@@ -42,12 +45,26 @@ auto succ::ThrusterController::on_deactivate(const rlc::State & /*previous_state
 
 auto succ::ThrusterController::on_export_reference_interfaces()
     -> std::vector<hif::CommandInterface> {
+    this->reference_interfaces_.resize(3);
+
     auto interfaces = std::vector<hif::CommandInterface>{};
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/enabled"), "enabled", &this->enabled.value));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/angle"), "angle", &this->angle.value));
+    interfaces.emplace_back(hif::CommandInterface(
+        this->get_node()->get_name() + std::string("/thrust"), "thrust", &this->thrust.value));
     return interfaces;
 }
 
 auto succ::ThrusterController::on_export_state_interfaces() -> std::vector<hif::StateInterface> {
     auto interfaces = std::vector<hif::StateInterface>{};
+
+    interfaces.emplace_back(hif::StateInterface(
+        this->get_node()->get_name() + std::string("/servo_current"), "servo_current",
+        &this->servo_current.value));
+    interfaces.emplace_back(hif::StateInterface(
+        this->get_node()->get_name() + std::string("/rpm"), "rpm", &this->rpm.value));
     return interfaces;
 }
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -24,7 +24,7 @@ auto succ::ThrusterController::state_interface_configuration() const
 auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
     this->get_node()->declare_parameter("id", 1);
     this->id = this->get_node()->get_parameter("id").as_int();
-    RCLCPP_INFO(get_node()->get_logger(), "Thruster ID: %ld", this->id);
+    RCLCPP_INFO(get_node()->get_logger(), "Thruster ID: %d", this->id);
     return cif::CallbackReturn::SUCCESS;
 }
 

--- a/src/sinsei_umiusi_control/hardware/can.cpp
+++ b/src/sinsei_umiusi_control/hardware/can.cpp
@@ -1,22 +1,10 @@
 #include "sinsei_umiusi_control/hardware/can.hpp"
 
+#include <regex>
+
 namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
-
-auto suchw::Can::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::Can::on_export_state_interfaces() -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::Can::on_export_command_interfaces() -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
 
 auto suchw::Can::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {

--- a/src/sinsei_umiusi_control/hardware/can.cpp
+++ b/src/sinsei_umiusi_control/hardware/can.cpp
@@ -1,7 +1,5 @@
 #include "sinsei_umiusi_control/hardware/can.hpp"
 
-#include <regex>
-
 namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;

--- a/src/sinsei_umiusi_control/hardware/headlights.cpp
+++ b/src/sinsei_umiusi_control/hardware/headlights.cpp
@@ -4,22 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::Headlights::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::Headlights::on_export_state_interfaces()
-    -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::Headlights::on_export_command_interfaces()
-    -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::Headlights::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;
@@ -32,4 +16,4 @@ auto suchw::Headlights::write(const rclcpp::Time & /*time*/, const rclcpp::Durat
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-    sinsei_umiusi_control::hardware::Headlights, hardware_interface::ActuatorInterface)
+    sinsei_umiusi_control::hardware::Headlights, hardware_interface::SystemInterface)

--- a/src/sinsei_umiusi_control/hardware/imu.cpp
+++ b/src/sinsei_umiusi_control/hardware/imu.cpp
@@ -4,15 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::Imu::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::Imu::on_export_state_interfaces() -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::Imu::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;

--- a/src/sinsei_umiusi_control/hardware/indicator_led.cpp
+++ b/src/sinsei_umiusi_control/hardware/indicator_led.cpp
@@ -12,8 +12,10 @@ auto suchw::IndicatorLed::read(const rclcpp::Time & /*time*/, const rclcpp::Dura
 auto suchw::IndicatorLed::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
     -> hif::return_type {
     // TODO: 以下はデバッグ用。実際はLEDの点灯処理に変更する
-    double enabled = static_cast<bool>(get_command("indicator_led/indicator_led/enabled"));
-    RCLCPP_INFO(get_logger(), enabled ? "true" : "false");
+    double enabled_raw = get_command("indicator_led/indicator_led/enabled");
+    auto enabled =
+        *reinterpret_cast<sinsei_umiusi_control::cmd::indicator_led::Enabled *>(&enabled_raw);
+    RCLCPP_INFO(get_logger(), enabled.value ? "true" : "false");
     return hif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/hardware/indicator_led.cpp
+++ b/src/sinsei_umiusi_control/hardware/indicator_led.cpp
@@ -11,6 +11,9 @@ auto suchw::IndicatorLed::read(const rclcpp::Time & /*time*/, const rclcpp::Dura
 
 auto suchw::IndicatorLed::write(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
     -> hif::return_type {
+    // TODO: 以下はデバッグ用。実際はLEDの点灯処理に変更する
+    double enabled = static_cast<bool>(get_command("indicator_led/indicator_led/enabled"));
+    RCLCPP_INFO(get_logger(), enabled ? "true" : "false");
     return hif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/hardware/indicator_led.cpp
+++ b/src/sinsei_umiusi_control/hardware/indicator_led.cpp
@@ -4,22 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::IndicatorLed::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::IndicatorLed::on_export_state_interfaces()
-    -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::IndicatorLed::on_export_command_interfaces()
-    -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::IndicatorLed::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;
@@ -32,4 +16,4 @@ auto suchw::IndicatorLed::write(const rclcpp::Time & /*time*/, const rclcpp::Dur
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-    sinsei_umiusi_control::hardware::IndicatorLed, hardware_interface::ActuatorInterface)
+    sinsei_umiusi_control::hardware::IndicatorLed, hardware_interface::SystemInterface)

--- a/src/sinsei_umiusi_control/hardware/raspi_camera.cpp
+++ b/src/sinsei_umiusi_control/hardware/raspi_camera.cpp
@@ -4,22 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::RaspiCamera::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::RaspiCamera::on_export_state_interfaces()
-    -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::RaspiCamera::on_export_command_interfaces()
-    -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::RaspiCamera::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;
@@ -32,4 +16,4 @@ auto suchw::RaspiCamera::write(const rclcpp::Time & /*time*/, const rclcpp::Dura
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-    sinsei_umiusi_control::hardware::RaspiCamera, hardware_interface::ActuatorInterface)
+    sinsei_umiusi_control::hardware::RaspiCamera, hardware_interface::SystemInterface)

--- a/src/sinsei_umiusi_control/hardware/thruster_direct.cpp
+++ b/src/sinsei_umiusi_control/hardware/thruster_direct.cpp
@@ -4,22 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::ThrusterDirect::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::ThrusterDirect::on_export_state_interfaces()
-    -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::ThrusterDirect::on_export_command_interfaces()
-    -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::ThrusterDirect::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;

--- a/src/sinsei_umiusi_control/hardware/usb_camera.cpp
+++ b/src/sinsei_umiusi_control/hardware/usb_camera.cpp
@@ -4,22 +4,6 @@ namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
 
-auto suchw::UsbCamera::on_init(const hif::HardwareInfo & /*info*/) -> hif::CallbackReturn {
-    return hif::CallbackReturn::SUCCESS;
-}
-
-auto suchw::UsbCamera::on_export_state_interfaces()
-    -> std::vector<hif::StateInterface::ConstSharedPtr> {
-    auto interfaces_to_export = std::vector<hif::StateInterface::ConstSharedPtr>{};
-    return interfaces_to_export;
-}
-
-auto suchw::UsbCamera::on_export_command_interfaces()
-    -> std::vector<hif::CommandInterface::SharedPtr> {
-    auto interfaces_to_export = std::vector<hif::CommandInterface::SharedPtr>{};
-    return interfaces_to_export;
-}
-
 auto suchw::UsbCamera::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*preiod*/)
     -> hif::return_type {
     return hif::return_type::OK;
@@ -32,4 +16,4 @@ auto suchw::UsbCamera::write(const rclcpp::Time & /*time*/, const rclcpp::Durati
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(
-    sinsei_umiusi_control::hardware::UsbCamera, hardware_interface::ActuatorInterface)
+    sinsei_umiusi_control::hardware::UsbCamera, hardware_interface::SystemInterface)

--- a/urdf/sinsei_umiusi_control/headlights.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/headlights.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
   <xacro:macro name="headlights">
-    <ros2_control name="headlights" type="actuator">
+    <ros2_control name="headlights" type="system">
       <hardware>
         <plugin>sinsei_umiusi_control/hardware/Headlights</plugin>
       </hardware>

--- a/urdf/sinsei_umiusi_control/imu.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/imu.urdf.xacro
@@ -5,11 +5,11 @@
       <hardware>
         <plugin>sinsei_umiusi_control/hardware/Imu</plugin>
       </hardware>
-      <gpio name="imu">
+      <sensor name="imu">
         <state_interface name="imu/orientation" />
         <state_interface name="imu/velocity" />
         <state_interface name="imu/temperature" />
-      </gpio>
+      </sensor>
     </ros2_control>
   </xacro:macro>
 </robot>

--- a/urdf/sinsei_umiusi_control/indicator_led.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/indicator_led.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
   <xacro:macro name="indicator_led">
-    <ros2_control name="indicator_led" type="actuator">
+    <ros2_control name="indicator_led" type="system">
       <hardware>
         <plugin>sinsei_umiusi_control/hardware/IndicatorLed</plugin>
       </hardware>

--- a/urdf/sinsei_umiusi_control/raspi_camera.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/raspi_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
   <xacro:macro name="raspi_camera">
-    <ros2_control name="raspi_camera" type="actuator">
+    <ros2_control name="raspi_camera" type="system">
       <hardware>
         <plugin>sinsei_umiusi_control/hardware/RaspiCamera</plugin>
       </hardware>

--- a/urdf/sinsei_umiusi_control/usb_camera.urdf.xacro
+++ b/urdf/sinsei_umiusi_control/usb_camera.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
   <xacro:macro name="usb_camera">
-    <ros2_control name="usb_camera" type="actuator">
+    <ros2_control name="usb_camera" type="system">
       <hardware>
         <plugin>sinsei_umiusi_control/hardware/UsbCamera</plugin>
       </hardware>


### PR DESCRIPTION
Hardware ComponentでCommand/State-interfacesをエクスポートし、Controllerを適切に設定することで正常にlaunchできたらマージします。

色々調べた結果、`on_export_**_interfaces`関数をoverrideして自力で実装するとコード量が膨大になりそうな上、double型のポインタしか渡せず不便だということがわかったので、URDFの記述を元に自動でエクスポートしてくれる新機能を利用する方針で進めてみます。