### PR TITLE
feat(launch): xacroへの引数渡しに対応

### DIFF
--- a/launch/launch.xml
+++ b/launch/launch.xml
@@ -5,8 +5,10 @@
   <let name="pkg_name" value="sinsei_umiusi_control" />
 
   <!-- Launch Arguments -->
+  <arg name="thruster_mode" default="can" />
+
   <arg name="robot_description"
-    default="$(command 'xacro $(find-pkg-share $(var pkg_name))/urdf/sinsei_umiusi_control.urdf.xacro')" />
+    default="$(command 'xacro $(find-pkg-share $(var pkg_name))/urdf/sinsei_umiusi_control.urdf.xacro thruster_mode:=\&apos;\&quot;$(var thruster_mode)\&quot;\&apos;')" />
 
   <arg
     name="robot_controllers_path"


### PR DESCRIPTION
以下のようにlaunch時にxacroへ引数を渡せるようになりました。

これと合わせてCIのmatrixを設定すれば`thruster_direct`のすり抜けが防げそうです。

```bash
ros2 launch sinsei_umiusi_control launch.xml thruster_mode:=direct
```
