### PR TITLE
chore: :arrow_up: modify devcontainer settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
     "vscode": {
       "extensions": [
         "charliermarsh.ruff",
+        "llvm-vs-code-extensions.vscode-clangd",
         "ms-iot.vscode-ros",
         "ms-python.python",
         "ms-vscode.cpptools",
@@ -30,11 +31,22 @@
         "python.analysis.inlayHints.variableTypes": true,
         "python.analysis.inlayHints.pytestParameters": true,
         "[cpp]": {
-          "editor.defaultFormatter": "ms-vscode.cpptools"
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
-        "C_Cpp.inlayHints.autoDeclarationTypes.enabled": true,
-        "C_Cpp.inlayHints.autoFunctionReturnTypes.enabled": true,
-        "C_Cpp.inlayHints.variableTypes.enabled": true,
+        "clangd.path": "clangd-18",
+        "clangd.arguments": [
+          "--compile-commands-dir=${workspaceFolder}/build"
+        ],
+        "clangd.fallbackFlags": [
+          "-std=c99",
+          "-std=gnu++17",
+          "-Wall",
+          "-Wextra",
+          "-Wpedantic"
+        ],
+        "C_Cpp.codeAnalysis.runAutomatically": false,
+        "C_Cpp.hover": "disabled",
+        "C_Cpp.intelliSenseEngine": "disabled",
         "[ros.msg]": {
           "editor.defaultFormatter": "ms-iot.vscode-ros"
         }

--- a/.docker/work/Dockerfile
+++ b/.docker/work/Dockerfile
@@ -4,9 +4,9 @@ FROM osrf/ros:${ros_distro}-desktop
 
 RUN apt-get update && apt-get install -y \
     git \
-    clang-format \
-    ros-${ROS_DISTRO}-ament-clang-format \
-    ros-${ROS_DISTRO}-ament-cmake-clang-format \
+    clangd-18 \
+    clang-format-18 \
+    clang-tidy-18 \
     ros-${ROS_DISTRO}-ros2-control \
     ros-${ROS_DISTRO}-ros2-controllers \
     ros-${ROS_DISTRO}-xacro \


### PR DESCRIPTION
close #48 

- Install clang-tools
- Enable clangd & disable c++ intellisense

VSCodeの環境が結構変わるので、実際に試してみてほしいです。

一回ビルドし直して`compile_commands.json`を生成しないととclangdが上手く動かないかも。