### PR TITLE
feat: 各controllerで`Loaned**Interface`が使えるようにする

### DIFF
--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -1,7 +1,6 @@
 #ifndef SINSEI_UMIUSI_CONTROL_APP_CONTROLLER_HPP
 #define SINSEI_UMIUSI_CONTROL_APP_CONTROLLER_HPP
 
-#include <optional>
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -43,7 +43,7 @@ class AppController : public controller_interface::ChainableControllerInterface 
     };
 
     std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
-        interface_helper_;
+        interface_helper;
 
   public:
     AppController() = default;

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -29,20 +29,20 @@ class AppController : public controller_interface::ChainableControllerInterface 
 
     auto compute_outputs() -> void;
 
-    static constexpr size_t cmd_size = 8;
-    static constexpr const char * cmd_interface_names[cmd_size] = {
+    static constexpr size_t CMD_SIZE = 8;
+    static constexpr const char * CMD_INTERFACE_NAMES[CMD_SIZE] = {
         "thruster_controller1/angle/angle", "thruster_controller1/thrust/thrust",
         "thruster_controller2/angle/angle", "thruster_controller2/thrust/thrust",
         "thruster_controller3/angle/angle", "thruster_controller3/thrust/thrust",
         "thruster_controller4/angle/angle", "thruster_controller4/thrust/thrust",
     };
-    static constexpr size_t state_size = 6;
-    static constexpr const char * state_interface_names[state_size] = {
+    static constexpr size_t STATE_SIZE = 6;
+    static constexpr const char * STATE_INTERFACE_NAMES[STATE_SIZE] = {
         "imu/imu/orientation_raw.x", "imu/imu/orientation_raw.y", "imu/imu/orientation_raw.z",
         "imu/imu/velocity_raw.x",    "imu/imu/velocity_raw.y",    "imu/imu/velocity_raw.z",
     };
 
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, cmd_size, state_size>>
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
         interface_helper_;
 
   public:

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -42,8 +42,7 @@ class AppController : public controller_interface::ChainableControllerInterface 
         "imu/imu/velocity_raw.x",    "imu/imu/velocity_raw.y",    "imu/imu/velocity_raw.z",
     };
 
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
-        interface_helper;
+    std::unique_ptr<InterfaceAccessHelper<CMD_SIZE, STATE_SIZE>> interface_helper;
 
   public:
     AppController() = default;

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -35,6 +35,9 @@ class AppController : public controller_interface::ChainableControllerInterface 
     suc::state::imu::Orientation imu_orientation;
     suc::state::imu::Velocity imu_velocity;
 
+    std::vector<std::string> cmd_interface_names;
+    std::vector<std::string> state_interface_names;
+
   public:
     AppController() = default;
 

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -21,8 +21,6 @@ namespace sinsei_umiusi_control::controller {
 
 class AppController : public controller_interface::ChainableControllerInterface {
   private:
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
-
     // Command interfaces (in)
     suc::cmd::app::Orientation target_orientation;
     suc::cmd::app::Velocity target_velocity;
@@ -31,8 +29,21 @@ class AppController : public controller_interface::ChainableControllerInterface 
     suc::state::imu::Orientation imu_orientation;
     suc::state::imu::Velocity imu_velocity;
 
-    std::vector<std::string> cmd_interface_names;
-    std::vector<std::string> state_interface_names;
+    static constexpr size_t cmd_size = 8;
+    static constexpr const char * cmd_interface_names[cmd_size] = {
+        "thruster_controller1/angle/angle", "thruster_controller1/thrust/thrust",
+        "thruster_controller2/angle/angle", "thruster_controller2/thrust/thrust",
+        "thruster_controller3/angle/angle", "thruster_controller3/thrust/thrust",
+        "thruster_controller4/angle/angle", "thruster_controller4/thrust/thrust",
+    };
+    static constexpr size_t state_size = 6;
+    static constexpr const char * state_interface_names[state_size] = {
+        "imu/imu/orientation_raw.x", "imu/imu/orientation_raw.y", "imu/imu/orientation_raw.z",
+        "imu/imu/velocity_raw.x",    "imu/imu/velocity_raw.y",    "imu/imu/velocity_raw.z",
+    };
+
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, cmd_size, state_size>>
+        interface_helper_;
 
   public:
     AppController() = default;

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -12,6 +12,7 @@
 #include "realtime_tools/realtime_publisher.hpp"
 #include "sinsei_umiusi_control/cmd/app.hpp"
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
+#include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/imu.hpp"
 
 namespace suc = sinsei_umiusi_control;
@@ -20,16 +21,11 @@ namespace sinsei_umiusi_control::controller {
 
 class AppController : public controller_interface::ChainableControllerInterface {
   private:
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
+
     // Command interfaces (in)
     suc::cmd::app::Orientation target_orientation;
     suc::cmd::app::Velocity target_velocity;
-    // Command interfaces (out)
-    std::array<std::optional<hardware_interface::LoanedCommandInterface>, 4> thruster_angle;
-    std::array<std::optional<hardware_interface::LoanedCommandInterface>, 4> thruster_thrust;
-
-    // State interfaces (in)
-    std::array<std::optional<hardware_interface::LoanedStateInterface>, 3> imu_orientation_raw;
-    std::array<std::optional<hardware_interface::LoanedStateInterface>, 3> imu_velocity_raw;
 
     // State interfaces (out)
     suc::state::imu::Orientation imu_orientation;

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -24,6 +24,11 @@ class AppController : public controller_interface::ChainableControllerInterface 
     suc::state::imu::Orientation imu_orientation;
     suc::state::imu::Velocity imu_velocity;
 
+    std::array<suc::cmd::thruster::Angle, 4> thruster_angles;
+    std::array<suc::cmd::thruster::Thrust, 4> thruster_thrusts;
+
+    auto compute_outputs() -> void;
+
     static constexpr size_t cmd_size = 8;
     static constexpr const char * cmd_interface_names[cmd_size] = {
         "thruster_controller1/angle/angle", "thruster_controller1/thrust/thrust",

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -5,10 +5,6 @@
 
 #include "controller_interface/chainable_controller_interface.hpp"
 #include "hardware_interface/hardware_interface/handle.hpp"
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "realtime_tools/realtime_buffer.hpp"
-#include "realtime_tools/realtime_publisher.hpp"
 #include "sinsei_umiusi_control/cmd/app.hpp"
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
 #include "sinsei_umiusi_control/interface_access_helper.hpp"

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -32,16 +32,64 @@ namespace sinsei_umiusi_control::controller {
 
 class GateController : public controller_interface::ControllerInterface {
   private:
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
-
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr indicator_led_enabled_subscriber;
 
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     cmd::indicator_led::Enabled indicator_led_enabled_ref;
 
-    std::vector<std::string> cmd_interface_names;
-    std::vector<std::string> state_interface_names;
+    static constexpr size_t cmd_size = 22;
+    static constexpr const char * cmd_interface_names[cmd_size] = {
+        "indicator_led/indicator_led/enabled",
+        "main_power/main_power/enabled",
+        "led_tape/led_tape/color",
+        "headlights/headlights/high_beam_enabled",
+        "headlights/headlights/low_beam_enabled",
+        "headlights/headlights/ir_enabled",
+        "usb_camera/usb_camera/config",
+        "raspi_camera/raspi_camera/config",
+        "thruster_controller1/servo_enabled/servo_enabled",
+        "thruster_controller2/servo_enabled/servo_enabled",
+        "thruster_controller3/servo_enabled/servo_enabled",
+        "thruster_controller4/servo_enabled/servo_enabled",
+        "thruster_controller1/esc_enabled/esc_enabled",
+        "thruster_controller2/esc_enabled/esc_enabled",
+        "thruster_controller3/esc_enabled/esc_enabled",
+        "thruster_controller4/esc_enabled/esc_enabled",
+        "app_controller/target_orientation.x/target_orientation.x",
+        "app_controller/target_orientation.y/target_orientation.y",
+        "app_controller/target_orientation.z/target_orientation.z",
+        "app_controller/target_velocity.x/target_velocity.x",
+        "app_controller/target_velocity.y/target_velocity.y",
+        "app_controller/target_velocity.z/target_velocity.z",
+    };
+    static constexpr size_t state_size = 21;
+    static constexpr const char * state_interface_names[state_size] = {
+        "main_power/main_power/battery_current",
+        "main_power/main_power/battery_voltage",
+        "main_power/main_power/temperature",
+        "main_power/main_power/water_leaked",
+        "thruster_controller1/servo_current/servo_current",
+        "thruster_controller2/servo_current/servo_current",
+        "thruster_controller3/servo_current/servo_current",
+        "thruster_controller4/servo_current/servo_current",
+        "thruster_controller1/rpm/rpm",
+        "thruster_controller2/rpm/rpm",
+        "thruster_controller3/rpm/rpm",
+        "thruster_controller4/rpm/rpm",
+        "app_controller/imu_orientation.x/imu_orientation.x",
+        "app_controller/imu_orientation.y/imu_orientation.y",
+        "app_controller/imu_orientation.z/imu_orientation.z",
+        "app_controller/imu_velocity.x/imu_velocity.x",
+        "app_controller/imu_velocity.y/imu_velocity.y",
+        "app_controller/imu_velocity.z/imu_velocity.z",
+        "imu/imu/temperature",
+        "usb_camera/usb_camera/image",
+        "raspi_camera/raspi_camera/image",
+    };
+
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, cmd_size, state_size>>
+        interface_helper_;
 
   public:
     GateController() = default;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -1,9 +1,6 @@
 #ifndef SINSEI_UMIUSI_CONTROL_GATE_CONTROLLER_HPP
 #define SINSEI_UMIUSI_CONTROL_GATE_CONTROLLER_HPP
 
-#include <optional>
-#include <vector>
-
 #include "controller_interface/controller_interface.hpp"
 #include "hardware_interface/hardware_interface/handle.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -76,8 +76,8 @@ class GateController : public controller_interface::ControllerInterface {
     state::imu::Temperature imu_temperature_ref;
     // TODO: usb_camera, raspi_camera
 
-    static constexpr size_t cmd_size = 22;
-    static constexpr const char * cmd_interface_names[cmd_size] = {
+    static constexpr size_t CMD_SIZE = 22;
+    static constexpr const char * CMD_INTERFACE_NAMES[CMD_SIZE] = {
         "indicator_led/indicator_led/enabled",
         "main_power/main_power/enabled",
         "led_tape/led_tape/color",
@@ -101,8 +101,8 @@ class GateController : public controller_interface::ControllerInterface {
         "app_controller/target_velocity.y/target_velocity.y",
         "app_controller/target_velocity.z/target_velocity.z",
     };
-    static constexpr size_t state_size = 21;
-    static constexpr const char * state_interface_names[state_size] = {
+    static constexpr size_t STATE_SIZE = 21;
+    static constexpr const char * STATE_INTERFACE_NAMES[STATE_SIZE] = {
         "main_power/main_power/battery_current",
         "main_power/main_power/battery_voltage",
         "main_power/main_power/temperature",
@@ -126,7 +126,7 @@ class GateController : public controller_interface::ControllerInterface {
         "raspi_camera/raspi_camera/image",
     };
 
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, cmd_size, state_size>>
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
         interface_helper_;
 
   public:

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -62,6 +62,9 @@ class GateController : public controller_interface::ControllerInterface {
     std::array<std::optional<hardware_interface::LoanedStateInterface>, 4> thruster_servo_current;
     std::array<std::optional<hardware_interface::LoanedStateInterface>, 4> thruster_rpm;
 
+    std::vector<std::string> cmd_interface_names;
+    std::vector<std::string> state_interface_names;
+
   public:
     GateController() = default;
 

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -127,7 +127,7 @@ class GateController : public controller_interface::ControllerInterface {
     };
 
     std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
-        interface_helper_;
+        interface_helper;
 
   public:
     GateController() = default;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -1,7 +1,10 @@
 #ifndef SINSEI_UMIUSI_CONTROL_GATE_CONTROLLER_HPP
 #define SINSEI_UMIUSI_CONTROL_GATE_CONTROLLER_HPP
 
+#include <rclcpp/publisher.hpp>
+
 #include "controller_interface/controller_interface.hpp"
+#include "geometry_msgs/msg/vector3.hpp"
 #include "sinsei_umiusi_control/cmd/app.hpp"
 #include "sinsei_umiusi_control/cmd/headlights.hpp"
 #include "sinsei_umiusi_control/cmd/indicator_led.hpp"
@@ -17,6 +20,9 @@
 #include "sinsei_umiusi_control/state/thruster.hpp"
 #include "sinsei_umiusi_control/state/usb_camera.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/color_rgba.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include "std_msgs/msg/int8.hpp"
 
 namespace suc = sinsei_umiusi_control;
 
@@ -24,11 +30,51 @@ namespace sinsei_umiusi_control::controller {
 
 class GateController : public controller_interface::ControllerInterface {
   private:
-    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr indicator_led_enabled_subscriber;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr main_power_enabled_subscriber;
+    rclcpp::Subscription<std_msgs::msg::ColorRGBA>::SharedPtr led_tape_color_subscriber;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr high_beam_enabled_subscriber;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr low_beam_enabled_subscriber;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr ir_enabled_subscriber;
+    // TODO: usb_camera, raspi_camera
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr servo_enabled_subscriber;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr esc_enabled_subscriber;
+    rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr target_orientation_subscriber;
+    rclcpp::Subscription<geometry_msgs::msg::Vector3>::SharedPtr target_velocity_subscriber;
 
-    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
+    rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr battery_current_publisher;
+    rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr battery_voltage_publisher;
+    rclcpp::Publisher<std_msgs::msg::Int8>::SharedPtr main_temperature_publisher;
+    rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr water_leaked_publisher;
+    std::array<rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr, 4> servo_current_publisher;
+    std::array<rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr, 4> rpm_publisher;
+    rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr imu_orientation_publisher;
+    rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr imu_velocity_publisher;
+    rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr imu_temperature_publisher;
+    // TODO: usb_camera, raspi_camera
+
     cmd::indicator_led::Enabled indicator_led_enabled_ref;
+    cmd::main_power::Enabled main_power_enabled_ref;
+    cmd::led_tape::Color led_tape_color_ref;
+    cmd::headlights::HighBeamEnabled high_beam_enabled_ref;
+    cmd::headlights::LowBeamEnabled low_beam_enabled_ref;
+    cmd::headlights::IrEnabled ir_enabled_ref;
+    // TODO: usb_camera, raspi_camera
+    cmd::thruster::ServoEnabled servo_enabled_ref;
+    cmd::thruster::EscEnabled esc_enabled_ref;
+    cmd::app::Orientation target_orientation_ref;
+    cmd::app::Velocity target_velocity_ref;
+
+    state::main_power::BatteryCurrent battery_current_ref;
+    state::main_power::BatteryVoltage battery_voltage_ref;
+    state::main_power::Temperature main_temperature_ref;
+    state::main_power::WaterLeaked water_leaked_ref;
+    std::array<state::thruster::ServoCurrent, 4> servo_current_ref;
+    std::array<state::thruster::Rpm, 4> rpm_ref;
+    state::imu::Orientation imu_orientation_ref;
+    state::imu::Velocity imu_velocity_ref;
+    state::imu::Temperature imu_temperature_ref;
+    // TODO: usb_camera, raspi_camera
 
     static constexpr size_t cmd_size = 22;
     static constexpr const char * cmd_interface_names[cmd_size] = {

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -18,6 +18,7 @@
 #include "sinsei_umiusi_control/cmd/raspi_camera.hpp"
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
 #include "sinsei_umiusi_control/cmd/usb_camera.hpp"
+#include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/imu.hpp"
 #include "sinsei_umiusi_control/state/main_power.hpp"
 #include "sinsei_umiusi_control/state/raspi_camera.hpp"
@@ -31,36 +32,13 @@ namespace sinsei_umiusi_control::controller {
 
 class GateController : public controller_interface::ControllerInterface {
   private:
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
+
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr indicator_led_enabled_subscriber;
 
+    // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     cmd::indicator_led::Enabled indicator_led_enabled_ref;
-
-    // Command interfaces (out)
-    std::optional<hardware_interface::LoanedCommandInterface> main_power_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> led_tape_color;
-    std::optional<hardware_interface::LoanedCommandInterface> indicator_led_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> high_beam_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> low_beam_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> ir_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> usb_camera_config;
-    std::optional<hardware_interface::LoanedCommandInterface> raspi_camera_config;
-    std::optional<hardware_interface::LoanedCommandInterface> thruster_enabled;
-    std::optional<hardware_interface::LoanedCommandInterface> target_orientation;
-    std::optional<hardware_interface::LoanedCommandInterface> target_velocity;
-
-    // State interfaces (in)
-    std::optional<hardware_interface::LoanedStateInterface> battery_current;
-    std::optional<hardware_interface::LoanedStateInterface> battery_voltage;
-    std::optional<hardware_interface::LoanedStateInterface> main_power_temperature;
-    std::optional<hardware_interface::LoanedStateInterface> water_leaked;
-    std::optional<hardware_interface::LoanedStateInterface> imu_orientation;
-    std::optional<hardware_interface::LoanedStateInterface> imu_velocity;
-    std::optional<hardware_interface::LoanedStateInterface> imu_temperature;
-    std::optional<hardware_interface::LoanedStateInterface> usb_camera_image;
-    std::optional<hardware_interface::LoanedStateInterface> raspi_camera_image;
-    std::array<std::optional<hardware_interface::LoanedStateInterface>, 4> thruster_servo_current;
-    std::array<std::optional<hardware_interface::LoanedStateInterface>, 4> thruster_rpm;
 
     std::vector<std::string> cmd_interface_names;
     std::vector<std::string> state_interface_names;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -126,8 +126,7 @@ class GateController : public controller_interface::ControllerInterface {
         "raspi_camera/raspi_camera/image",
     };
 
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>
-        interface_helper;
+    std::unique_ptr<InterfaceAccessHelper<CMD_SIZE, STATE_SIZE>> interface_helper;
 
   public:
     GateController() = default;

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -2,11 +2,6 @@
 #define SINSEI_UMIUSI_CONTROL_GATE_CONTROLLER_HPP
 
 #include "controller_interface/controller_interface.hpp"
-#include "hardware_interface/hardware_interface/handle.hpp"
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "realtime_tools/realtime_buffer.hpp"
-#include "realtime_tools/realtime_publisher.hpp"
 #include "sinsei_umiusi_control/cmd/app.hpp"
 #include "sinsei_umiusi_control/cmd/headlights.hpp"
 #include "sinsei_umiusi_control/cmd/indicator_led.hpp"

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -11,6 +11,7 @@
 #include "realtime_tools/realtime_buffer.hpp"
 #include "realtime_tools/realtime_publisher.hpp"
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
+#include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/thruster.hpp"
 
 namespace suc = sinsei_umiusi_control;
@@ -24,19 +25,13 @@ enum ThrusterMode {
 
 class ThrusterController : public controller_interface::ChainableControllerInterface {
   private:
+    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
+
     // Command interfaces (in)
     suc::cmd::thruster::ServoEnabled servo_enabled;
     suc::cmd::thruster::EscEnabled esc_enabled;
     suc::cmd::thruster::Angle angle;
     suc::cmd::thruster::Thrust thrust;
-
-    // Command interfaces (out)
-    std::optional<hardware_interface::LoanedCommandInterface> servo_enabled_raw;
-    std::optional<hardware_interface::LoanedCommandInterface> esc_enabled_raw;
-
-    // State interfaces (in)
-    std::optional<hardware_interface::LoanedStateInterface> servo_current_raw;
-    std::optional<hardware_interface::LoanedStateInterface> rpm_raw;
 
     // State interfaces (out)
     suc::state::thruster::ServoCurrent servo_current;

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -2,7 +2,6 @@
 #define SINSEI_UMIUSI_CONTROL_THRUSTER_CONTROLLER_HPP
 
 #include <cstddef>
-#include <optional>
 #include <vector>
 
 #include "controller_interface/chainable_controller_interface.hpp"

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -6,10 +6,6 @@
 
 #include "controller_interface/chainable_controller_interface.hpp"
 #include "hardware_interface/hardware_interface/handle.hpp"
-#include "hardware_interface/types/hardware_interface_type_values.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "realtime_tools/realtime_buffer.hpp"
-#include "realtime_tools/realtime_publisher.hpp"
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
 #include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/thruster.hpp"

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -42,6 +42,9 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::ServoCurrent servo_current;
     suc::state::thruster::Rpm rpm;
 
+    std::vector<std::string> cmd_interface_names;
+    std::vector<std::string> state_interface_names;
+
     // Thruster ID (1~4)
     uint8_t id;
 

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -57,10 +57,10 @@ class ThrusterController : public controller_interface::ChainableControllerInter
 
     std::unique_ptr<
         InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>
-        can_interface_helper_;
+        can_interface_helper;
     std::unique_ptr<
         InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>
-        direct_interface_helper_;
+        direct_interface_helper;
 
     // Thruster ID (1~4)
     uint8_t id;

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -55,11 +55,8 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     static constexpr size_t DIRECT_STATE_SIZE = 1;
     static constexpr const char * DIRECT_STATE_INTERFACE_NAMES[DIRECT_STATE_SIZE] = {};
 
-    std::unique_ptr<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>
-        can_interface_helper;
-    std::unique_ptr<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>
+    std::unique_ptr<InterfaceAccessHelper<CAN_CMD_SIZE, CAN_STATE_SIZE>> can_interface_helper;
+    std::unique_ptr<InterfaceAccessHelper<DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>
         direct_interface_helper;
 
     // Thruster ID (1~4)

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -1,6 +1,7 @@
 #ifndef SINSEI_UMIUSI_CONTROL_THRUSTER_CONTROLLER_HPP
 #define SINSEI_UMIUSI_CONTROL_THRUSTER_CONTROLLER_HPP
 
+#include <cstddef>
 #include <optional>
 #include <vector>
 
@@ -25,8 +26,6 @@ enum ThrusterMode {
 
 class ThrusterController : public controller_interface::ChainableControllerInterface {
   private:
-    std::unique_ptr<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>> interface_helper_;
-
     // Command interfaces (in)
     suc::cmd::thruster::ServoEnabled servo_enabled;
     suc::cmd::thruster::EscEnabled esc_enabled;
@@ -37,8 +36,34 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::ServoCurrent servo_current;
     suc::state::thruster::Rpm rpm;
 
-    std::vector<std::string> cmd_interface_names;
-    std::vector<std::string> state_interface_names;
+    static constexpr size_t can_cmd_size = 4;
+    static constexpr const char * can_cmd_interface_names[can_cmd_size] = {
+        "servo/servo/enabled_raw",
+        "servo/servo/angle_raw",
+        "esc/esc/enabled_raw",
+        "esc/esc/thrust_raw",
+    };
+    static constexpr size_t can_state_size = 2;
+    static constexpr const char * can_state_interface_names[can_state_size] = {
+        "servo/servo/servo_current_raw",
+        "esc/esc/rpm_raw",
+    };
+    static constexpr size_t direct_cmd_size = 4;
+    static constexpr const char * direct_cmd_interface_names[direct_cmd_size] = {
+        "servo_direct/servo_direct/enabled_raw",
+        "servo_direct/servo_direct/angle_raw",
+        "esc_direct/esc_direct/enabled_raw",
+        "esc_direct/esc_direct/thrust_raw",
+    };
+    static constexpr size_t direct_state_size = 1;
+    static constexpr const char * direct_state_interface_names[direct_state_size] = {};
+
+    std::unique_ptr<
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, can_cmd_size, can_state_size>>
+        can_interface_helper_;
+    std::unique_ptr<
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, direct_cmd_size, direct_state_size>>
+        direct_interface_helper_;
 
     // Thruster ID (1~4)
     uint8_t id;

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -14,7 +14,7 @@ namespace suc = sinsei_umiusi_control;
 
 namespace sinsei_umiusi_control::controller {
 
-enum ThrusterMode {
+enum class ThrusterMode {
     Can,
     Direct,
 };

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -36,6 +36,7 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::ServoCurrent servo_current;
     suc::state::thruster::Rpm rpm;
 
+    // 正式なinterface名は前に`thruster(_direct)(1-4)/`がつくが、リストを静的にするため特別に省略している
     static constexpr size_t can_cmd_size = 4;
     static constexpr const char * can_cmd_interface_names[can_cmd_size] = {
         "servo/servo/enabled_raw",
@@ -55,6 +56,7 @@ class ThrusterController : public controller_interface::ChainableControllerInter
         "esc_direct/esc_direct/enabled_raw",
         "esc_direct/esc_direct/thrust_raw",
     };
+    // `thruster_mode`が`direct`のときState Interfaceは存在しないが、配列のサイズは0にできないので1としている
     static constexpr size_t direct_state_size = 1;
     static constexpr const char * direct_state_interface_names[direct_state_size] = {};
 

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -32,34 +32,34 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     suc::state::thruster::Rpm rpm;
 
     // 正式なinterface名は前に`thruster(_direct)(1-4)/`がつくが、リストを静的にするため特別に省略している
-    static constexpr size_t can_cmd_size = 4;
-    static constexpr const char * can_cmd_interface_names[can_cmd_size] = {
+    static constexpr size_t CAN_CMD_SIZE = 4;
+    static constexpr const char * CAN_CMD_INTERFACE_NAMES[CAN_CMD_SIZE] = {
         "servo/servo/enabled_raw",
         "servo/servo/angle_raw",
         "esc/esc/enabled_raw",
         "esc/esc/thrust_raw",
     };
-    static constexpr size_t can_state_size = 2;
-    static constexpr const char * can_state_interface_names[can_state_size] = {
+    static constexpr size_t CAN_STATE_SIZE = 2;
+    static constexpr const char * CAN_STATE_INTERFACE_NAMES[CAN_STATE_SIZE] = {
         "servo/servo/servo_current_raw",
         "esc/esc/rpm_raw",
     };
-    static constexpr size_t direct_cmd_size = 4;
-    static constexpr const char * direct_cmd_interface_names[direct_cmd_size] = {
+    static constexpr size_t DIRECT_CMD_SIZE = 4;
+    static constexpr const char * DIRECT_CMD_INTERFACE_NAMES[DIRECT_CMD_SIZE] = {
         "servo_direct/servo_direct/enabled_raw",
         "servo_direct/servo_direct/angle_raw",
         "esc_direct/esc_direct/enabled_raw",
         "esc_direct/esc_direct/thrust_raw",
     };
     // `thruster_mode`が`direct`のときState Interfaceは存在しないが、配列のサイズは0にできないので1としている
-    static constexpr size_t direct_state_size = 1;
-    static constexpr const char * direct_state_interface_names[direct_state_size] = {};
+    static constexpr size_t DIRECT_STATE_SIZE = 1;
+    static constexpr const char * DIRECT_STATE_INTERFACE_NAMES[DIRECT_STATE_SIZE] = {};
 
     std::unique_ptr<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, can_cmd_size, can_state_size>>
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>
         can_interface_helper_;
     std::unique_ptr<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, direct_cmd_size, direct_state_size>>
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>
         direct_interface_helper_;
 
     // Thruster ID (1~4)

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -1,0 +1,87 @@
+#ifndef SINSEI_UMIUSI_CONTROL_INTERFACE_ACCESS_HELPER_HPP
+#define SINSEI_UMIUSI_CONTROL_INTERFACE_ACCESS_HELPER_HPP
+
+#include <hardware_interface/loaned_command_interface.hpp>
+#include <hardware_interface/loaned_state_interface.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+namespace sinsei_umiusi_control {
+
+template <typename NodeLike>
+class InterfaceAccessHelper {
+  public:
+    InterfaceAccessHelper(
+        NodeLike * node, std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces,
+        std::vector<std::string> & cmd_names,
+        std::vector<hardware_interface::LoanedStateInterface> & state_interfaces,
+        std::vector<std::string> & state_names)
+    : node_(node),
+      cmd_interfaces_(cmd_interfaces),
+      cmd_names_(cmd_names),
+      state_interfaces_(state_interfaces),
+      state_names_(state_names) {}
+
+    auto get_index(const std::string & name, const std::vector<std::string> & names)
+        -> std::optional<size_t> {
+        auto it = std::find(names.begin(), names.end(), name);
+        if (it != names.end()) {
+            auto index = std::distance(names.begin(), it);
+            return index;
+        }
+        return std::nullopt;
+    }
+
+    auto set_cmd_value(const std::string & name, const double & value) -> void {
+        auto index_opt = this->get_index(name, cmd_names_);
+        if (!index_opt.has_value()) {
+            RCLCPP_ERROR(node_->get_logger(), "Command interface not found: %s", name.c_str());
+            return;
+        }
+        size_t index = index_opt.value();
+        if (index >= cmd_interfaces_.size()) {
+            RCLCPP_ERROR(
+                node_->get_logger(), "Index out of range for command interfaces: %s", name.c_str());
+            return;
+        }
+        auto & interface = cmd_interfaces_[index];
+        if (!interface.set_value(value)) {
+            RCLCPP_WARN(
+                node_->get_logger(), "Failed to set value for: %s", interface.get_name().c_str());
+        }
+    }
+
+    template <typename T>
+    auto get_state_value(const std::string & name, T & target) -> void {
+        auto index_opt = this->get_index(name, state_names_);
+        if (!index_opt.has_value()) {
+            RCLCPP_ERROR(node_->get_logger(), "State interface not found: %s", name.c_str());
+            return;
+        }
+        size_t index = index_opt.value();
+        if (index >= state_interfaces_.size()) {
+            RCLCPP_ERROR(
+                node_->get_logger(), "Index out of range for state interfaces: %s", name.c_str());
+            return;
+        }
+        auto & interface = state_interfaces_[index];
+        auto opt = interface.get_optional();
+        if (!opt.has_value()) {
+            RCLCPP_ERROR(
+                node_->get_logger(), "State interface not ready: %s", interface.get_name().c_str());
+            return;
+        }
+        target = *reinterpret_cast<T *>(&opt.value());
+    }
+
+  private:
+    NodeLike * node_;
+    std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces_;
+    std::vector<std::string> & cmd_names_;
+    std::vector<hardware_interface::LoanedStateInterface> & state_interfaces_;
+    std::vector<std::string> & state_names_;
+};
+
+}  // namespace sinsei_umiusi_control
+
+#endif  // SINSEI_UMIUSI_CONTROL_INTERFACE_ACCESS_HELPER_HPP

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -1,6 +1,7 @@
 #ifndef SINSEI_UMIUSI_CONTROL_INTERFACE_ACCESS_HELPER_HPP
 #define SINSEI_UMIUSI_CONTROL_INTERFACE_ACCESS_HELPER_HPP
 
+#include <cstddef>
 #include <hardware_interface/loaned_command_interface.hpp>
 #include <hardware_interface/loaned_state_interface.hpp>
 #include <optional>
@@ -8,58 +9,39 @@
 #include <vector>
 namespace sinsei_umiusi_control {
 
-template <typename NodeLike>
+template <typename NodeLike, std::size_t CmdSize, std::size_t StateSize>
 class InterfaceAccessHelper {
   public:
     InterfaceAccessHelper(
         NodeLike * node, std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces,
-        std::vector<std::string> & cmd_names,
+        const char * const (&cmd_names)[CmdSize],
         std::vector<hardware_interface::LoanedStateInterface> & state_interfaces,
-        std::vector<std::string> & state_names)
+        const char * const (&state_names)[StateSize])
     : node_(node),
       cmd_interfaces_(cmd_interfaces),
       cmd_names_(cmd_names),
       state_interfaces_(state_interfaces),
       state_names_(state_names) {}
 
-    auto get_index(const std::string & name, const std::vector<std::string> & names)
-        -> std::optional<size_t> {
-        auto it = std::find(names.begin(), names.end(), name);
-        if (it != names.end()) {
-            auto index = std::distance(names.begin(), it);
-            return index;
-        }
-        return std::nullopt;
-    }
-
-    auto set_cmd_value(const std::string & name, const double & value) -> void {
-        auto index_opt = this->get_index(name, cmd_names_);
-        if (!index_opt.has_value()) {
-            RCLCPP_ERROR(node_->get_logger(), "Command interface not found: %s", name.c_str());
-            return;
-        }
-        size_t index = index_opt.value();
+    template <typename T>
+    auto set_cmd_value(const std::size_t & index, const T & value) -> void {
         if (index >= cmd_interfaces_.size()) {
+            const std::string name = cmd_names_[index];
             RCLCPP_ERROR(
                 node_->get_logger(), "Index out of range for command interfaces: %s", name.c_str());
             return;
         }
         auto & interface = cmd_interfaces_[index];
-        if (!interface.set_value(value)) {
+        if (!interface.set_value(*reinterpret_cast<const double *>(&value))) {
             RCLCPP_WARN(
                 node_->get_logger(), "Failed to set value for: %s", interface.get_name().c_str());
         }
     }
 
     template <typename T>
-    auto get_state_value(const std::string & name, T & target) -> void {
-        auto index_opt = this->get_index(name, state_names_);
-        if (!index_opt.has_value()) {
-            RCLCPP_ERROR(node_->get_logger(), "State interface not found: %s", name.c_str());
-            return;
-        }
-        size_t index = index_opt.value();
+    auto get_state_value(const std::size_t & index, T & target) -> void {
         if (index >= state_interfaces_.size()) {
+            const std::string name = state_names_[index];
             RCLCPP_ERROR(
                 node_->get_logger(), "Index out of range for state interfaces: %s", name.c_str());
             return;
@@ -77,9 +59,9 @@ class InterfaceAccessHelper {
   private:
     NodeLike * node_;
     std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces_;
-    std::vector<std::string> & cmd_names_;
+    const char * const (&cmd_names_)[CmdSize];
     std::vector<hardware_interface::LoanedStateInterface> & state_interfaces_;
-    std::vector<std::string> & state_names_;
+    const char * const (&state_names_)[StateSize];
 };
 
 }  // namespace sinsei_umiusi_control

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -9,11 +9,12 @@
 #include <vector>
 namespace sinsei_umiusi_control {
 
-template <typename NodeLike, std::size_t CMD_SIZE, std::size_t STATE_SIZE>
+template <std::size_t CMD_SIZE, std::size_t STATE_SIZE>
 class InterfaceAccessHelper {
   public:
     InterfaceAccessHelper(
-        NodeLike * node, std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces,
+        rclcpp_lifecycle::LifecycleNode * node,
+        std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces,
         const char * const (&cmd_names)[CMD_SIZE],
         std::vector<hardware_interface::LoanedStateInterface> & state_interfaces,
         const char * const (&state_names)[STATE_SIZE])
@@ -60,7 +61,7 @@ class InterfaceAccessHelper {
     }
 
   private:
-    NodeLike * node_;
+    rclcpp_lifecycle::LifecycleNode * node_;
     std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces_;
     const char * const (&cmd_names_)[CMD_SIZE];
     std::vector<hardware_interface::LoanedStateInterface> & state_interfaces_;

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -24,36 +24,39 @@ class InterfaceAccessHelper {
       state_names_(state_names) {}
 
     template <typename T>
-    auto set_cmd_value(const std::size_t & index, const T & value) -> void {
+    auto set_cmd_value(const std::size_t & index, const T & value) -> bool {
         if (index >= cmd_interfaces_.size()) {
             const std::string name = cmd_names_[index];
             RCLCPP_ERROR(
                 node_->get_logger(), "Index out of range for command interfaces: %s", name.c_str());
-            return;
+            return false;
         }
         auto & interface = cmd_interfaces_[index];
-        if (!interface.set_value(*reinterpret_cast<const double *>(&value))) {
+        auto res = interface.set_value(*reinterpret_cast<const double *>(&value));
+        if (!res) {
             RCLCPP_WARN(
                 node_->get_logger(), "Failed to set value for: %s", interface.get_name().c_str());
         }
+        return res;
     }
 
     template <typename T>
-    auto get_state_value(const std::size_t & index, T & target) -> void {
+    auto get_state_value(const std::size_t & index, T & target) -> bool {
         if (index >= state_interfaces_.size()) {
             const std::string name = state_names_[index];
             RCLCPP_ERROR(
                 node_->get_logger(), "Index out of range for state interfaces: %s", name.c_str());
-            return;
+            return false;
         }
         auto & interface = state_interfaces_[index];
         auto opt = interface.get_optional();
         if (!opt.has_value()) {
             RCLCPP_ERROR(
                 node_->get_logger(), "State interface not ready: %s", interface.get_name().c_str());
-            return;
+            return false;
         }
         target = *reinterpret_cast<T *>(&opt.value());
+        return true;
     }
 
   private:

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -9,14 +9,14 @@
 #include <vector>
 namespace sinsei_umiusi_control {
 
-template <typename NodeLike, std::size_t CmdSize, std::size_t StateSize>
+template <typename NodeLike, std::size_t CMD_SIZE, std::size_t STATE_SIZE>
 class InterfaceAccessHelper {
   public:
     InterfaceAccessHelper(
         NodeLike * node, std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces,
-        const char * const (&cmd_names)[CmdSize],
+        const char * const (&cmd_names)[CMD_SIZE],
         std::vector<hardware_interface::LoanedStateInterface> & state_interfaces,
-        const char * const (&state_names)[StateSize])
+        const char * const (&state_names)[STATE_SIZE])
     : node_(node),
       cmd_interfaces_(cmd_interfaces),
       cmd_names_(cmd_names),
@@ -59,9 +59,9 @@ class InterfaceAccessHelper {
   private:
     NodeLike * node_;
     std::vector<hardware_interface::LoanedCommandInterface> & cmd_interfaces_;
-    const char * const (&cmd_names_)[CmdSize];
+    const char * const (&cmd_names_)[CMD_SIZE];
     std::vector<hardware_interface::LoanedStateInterface> & state_interfaces_;
-    const char * const (&state_names_)[StateSize];
+    const char * const (&state_names_)[STATE_SIZE];
 };
 
 }  // namespace sinsei_umiusi_control

--- a/include/sinsei_umiusi_control/util.hpp
+++ b/include/sinsei_umiusi_control/util.hpp
@@ -4,6 +4,8 @@
 #include <cstddef>
 namespace sinsei_umiusi_control::util {
 
+// ref: https://stackoverflow.com/questions/51114180/constexpr-find-for-array-using-c17
+
 // `constexpr`に対応した文字列比較関数
 constexpr bool equals(const char * a, const char * b) {
     for (std::size_t i = 0;; ++i) {

--- a/include/sinsei_umiusi_control/util.hpp
+++ b/include/sinsei_umiusi_control/util.hpp
@@ -1,0 +1,29 @@
+#ifndef SINSEI_UMIUSI_CONTROL_UTIL_HPP
+#define SINSEI_UMIUSI_CONTROL_UTIL_HPP
+
+#include <cstddef>
+namespace sinsei_umiusi_control::util {
+
+// `constexpr`に対応した文字列比較関数
+constexpr bool equals(const char * a, const char * b) {
+    for (std::size_t i = 0;; ++i) {
+        if (a[i] != b[i]) return false;
+        if (a[i] == 0) break;
+    }
+    return true;
+}
+
+// `constexpr`に対応した文字列のインデックス取得関数
+template <std::size_t size>
+constexpr auto get_index(const char * name, const char * const (&array)[size]) -> std::size_t {
+    for (size_t i = 0; i < size; ++i) {
+        if (equals(array[i], name)) {
+            return i;
+        }
+    }
+    return size;
+}
+
+}  // namespace sinsei_umiusi_control::util
+
+#endif  // SINSEI_UMIUSI_CONTROL_UTIL_HPP

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -8,30 +8,14 @@ namespace cif = controller_interface;
 auto succ::AppController::command_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        {
-            "thruster_controller1/angle/angle",
-            "thruster_controller2/angle/angle",
-            "thruster_controller3/angle/angle",
-            "thruster_controller4/angle/angle",
-            "thruster_controller1/thrust/thrust",
-            "thruster_controller2/thrust/thrust",
-            "thruster_controller3/thrust/thrust",
-            "thruster_controller4/thrust/thrust",
-        },
+        this->cmd_interface_names,
     };
 }
 
 auto succ::AppController::state_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        {
-            "imu/imu/orientation_raw.x",
-            "imu/imu/orientation_raw.y",
-            "imu/imu/orientation_raw.z",
-            "imu/imu/velocity_raw.x",
-            "imu/imu/velocity_raw.y",
-            "imu/imu/velocity_raw.z",
-        },
+        this->state_interface_names,
     };
 }
 
@@ -39,6 +23,16 @@ auto succ::AppController::on_init() -> cif::CallbackReturn { return cif::Callbac
 
 auto succ::AppController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
+    this->cmd_interface_names = {
+        "thruster_controller1/angle/angle", "thruster_controller1/thrust/thrust",
+        "thruster_controller2/angle/angle", "thruster_controller2/thrust/thrust",
+        "thruster_controller3/angle/angle", "thruster_controller3/thrust/thrust",
+        "thruster_controller4/angle/angle", "thruster_controller4/thrust/thrust",
+    };
+    this->state_interface_names = {
+        "imu/imu/orientation_raw.x", "imu/imu/orientation_raw.y", "imu/imu/orientation_raw.z",
+        "imu/imu/velocity_raw.x",    "imu/imu/velocity_raw.y",    "imu/imu/velocity_raw.z",
+    };
     return cif::CallbackReturn::SUCCESS;
 }
 

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -112,31 +112,31 @@ auto succ::AppController::update_and_write_commands(
     // 姿勢制御の関数を呼び出す
     this->compute_outputs();
 
-    constexpr auto angle1_index =
+    constexpr auto ANGLE1_INDEX =
         suc_util::get_index("thruster_controller1/angle/angle", CMD_INTERFACE_NAMES);
-    constexpr auto thrust1_index =
+    constexpr auto THRUST1_INDEX =
         suc_util::get_index("thruster_controller1/thrust/thrust", CMD_INTERFACE_NAMES);
-    constexpr auto angle2_index =
+    constexpr auto ANGLE2_INDEX =
         suc_util::get_index("thruster_controller2/angle/angle", CMD_INTERFACE_NAMES);
-    constexpr auto thrust2_index =
+    constexpr auto THRUST2_INDEX =
         suc_util::get_index("thruster_controller2/thrust/thrust", CMD_INTERFACE_NAMES);
-    constexpr auto angle3_index =
+    constexpr auto ANGLE3_INDEX =
         suc_util::get_index("thruster_controller3/angle/angle", CMD_INTERFACE_NAMES);
-    constexpr auto thrust3_index =
+    constexpr auto THRUST3_INDEX =
         suc_util::get_index("thruster_controller3/thrust/thrust", CMD_INTERFACE_NAMES);
-    constexpr auto angle4_index =
+    constexpr auto ANGLE4_INDEX =
         suc_util::get_index("thruster_controller4/angle/angle", CMD_INTERFACE_NAMES);
-    constexpr auto thrust4_index =
+    constexpr auto THRUST4_INDEX =
         suc_util::get_index("thruster_controller4/thrust/thrust", CMD_INTERFACE_NAMES);
 
-    this->interface_helper->set_cmd_value(angle1_index, this->thruster_angles[0]);
-    this->interface_helper->set_cmd_value(thrust1_index, this->thruster_thrusts[0]);
-    this->interface_helper->set_cmd_value(angle2_index, this->thruster_angles[1]);
-    this->interface_helper->set_cmd_value(thrust2_index, this->thruster_thrusts[1]);
-    this->interface_helper->set_cmd_value(angle3_index, this->thruster_angles[2]);
-    this->interface_helper->set_cmd_value(thrust3_index, this->thruster_thrusts[2]);
-    this->interface_helper->set_cmd_value(angle4_index, this->thruster_angles[3]);
-    this->interface_helper->set_cmd_value(thrust4_index, this->thruster_thrusts[3]);
+    this->interface_helper->set_cmd_value(ANGLE1_INDEX, this->thruster_angles[0]);
+    this->interface_helper->set_cmd_value(THRUST1_INDEX, this->thruster_thrusts[0]);
+    this->interface_helper->set_cmd_value(ANGLE2_INDEX, this->thruster_angles[1]);
+    this->interface_helper->set_cmd_value(THRUST2_INDEX, this->thruster_thrusts[1]);
+    this->interface_helper->set_cmd_value(ANGLE3_INDEX, this->thruster_angles[2]);
+    this->interface_helper->set_cmd_value(THRUST3_INDEX, this->thruster_thrusts[2]);
+    this->interface_helper->set_cmd_value(ANGLE4_INDEX, this->thruster_angles[3]);
+    this->interface_helper->set_cmd_value(THRUST4_INDEX, this->thruster_thrusts[3]);
 
     constexpr auto orientation_x_index =
         suc_util::get_index("imu/imu/orientation_raw.x", STATE_INTERFACE_NAMES);

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -124,12 +124,12 @@ auto succ::AppController::update_and_write_commands(
     constexpr auto velocity_z_index =
         suc_util::get_index("imu/imu/velocity_raw.z", state_interface_names);
 
-    this->interface_helper_->get_state_value(orientation_x_index, this->target_orientation.x);
-    this->interface_helper_->get_state_value(orientation_y_index, this->target_orientation.y);
-    this->interface_helper_->get_state_value(orientation_z_index, this->target_orientation.z);
-    this->interface_helper_->get_state_value(velocity_x_index, this->target_velocity.x);
-    this->interface_helper_->get_state_value(velocity_y_index, this->target_velocity.y);
-    this->interface_helper_->get_state_value(velocity_z_index, this->target_velocity.z);
+    this->interface_helper_->get_state_value(orientation_x_index, this->imu_orientation.x);
+    this->interface_helper_->get_state_value(orientation_y_index, this->imu_orientation.y);
+    this->interface_helper_->get_state_value(orientation_z_index, this->imu_orientation.z);
+    this->interface_helper_->get_state_value(velocity_x_index, this->imu_velocity.x);
+    this->interface_helper_->get_state_value(velocity_y_index, this->imu_velocity.y);
+    this->interface_helper_->get_state_value(velocity_z_index, this->imu_velocity.z);
 
     return cif::return_type::OK;
 }

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -10,7 +10,7 @@ namespace cif = controller_interface;
 
 auto succ::AppController::command_interface_configuration() const -> cif::InterfaceConfiguration {
     std::vector<std::string> cmd_names(
-        std::begin(this->cmd_interface_names), std::end(this->cmd_interface_names));
+        std::begin(this->CMD_INTERFACE_NAMES), std::end(this->CMD_INTERFACE_NAMES));
 
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
@@ -20,7 +20,7 @@ auto succ::AppController::command_interface_configuration() const -> cif::Interf
 
 auto succ::AppController::state_interface_configuration() const -> cif::InterfaceConfiguration {
     std::vector<std::string> state_names(
-        std::begin(this->state_interface_names), std::end(this->state_interface_names));
+        std::begin(this->STATE_INTERFACE_NAMES), std::end(this->STATE_INTERFACE_NAMES));
 
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
@@ -31,8 +31,8 @@ auto succ::AppController::state_interface_configuration() const -> cif::Interfac
 auto succ::AppController::on_init() -> cif::CallbackReturn {
     this->interface_helper_ =
         std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, 8, 6>>(
-            this->get_node().get(), this->command_interfaces_, this->cmd_interface_names,
-            this->state_interfaces_, this->state_interface_names);
+            this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
+            this->state_interfaces_, this->STATE_INTERFACE_NAMES);
 
     return cif::CallbackReturn::SUCCESS;
 }
@@ -113,21 +113,21 @@ auto succ::AppController::update_and_write_commands(
     this->compute_outputs();
 
     constexpr auto angle1_index =
-        suc_util::get_index("thruster_controller1/angle/angle", cmd_interface_names);
+        suc_util::get_index("thruster_controller1/angle/angle", CMD_INTERFACE_NAMES);
     constexpr auto thrust1_index =
-        suc_util::get_index("thruster_controller1/thrust/thrust", cmd_interface_names);
+        suc_util::get_index("thruster_controller1/thrust/thrust", CMD_INTERFACE_NAMES);
     constexpr auto angle2_index =
-        suc_util::get_index("thruster_controller2/angle/angle", cmd_interface_names);
+        suc_util::get_index("thruster_controller2/angle/angle", CMD_INTERFACE_NAMES);
     constexpr auto thrust2_index =
-        suc_util::get_index("thruster_controller2/thrust/thrust", cmd_interface_names);
+        suc_util::get_index("thruster_controller2/thrust/thrust", CMD_INTERFACE_NAMES);
     constexpr auto angle3_index =
-        suc_util::get_index("thruster_controller3/angle/angle", cmd_interface_names);
+        suc_util::get_index("thruster_controller3/angle/angle", CMD_INTERFACE_NAMES);
     constexpr auto thrust3_index =
-        suc_util::get_index("thruster_controller3/thrust/thrust", cmd_interface_names);
+        suc_util::get_index("thruster_controller3/thrust/thrust", CMD_INTERFACE_NAMES);
     constexpr auto angle4_index =
-        suc_util::get_index("thruster_controller4/angle/angle", cmd_interface_names);
+        suc_util::get_index("thruster_controller4/angle/angle", CMD_INTERFACE_NAMES);
     constexpr auto thrust4_index =
-        suc_util::get_index("thruster_controller4/thrust/thrust", cmd_interface_names);
+        suc_util::get_index("thruster_controller4/thrust/thrust", CMD_INTERFACE_NAMES);
 
     this->interface_helper_->set_cmd_value(angle1_index, this->thruster_angles[0]);
     this->interface_helper_->set_cmd_value(thrust1_index, this->thruster_thrusts[0]);
@@ -139,17 +139,17 @@ auto succ::AppController::update_and_write_commands(
     this->interface_helper_->set_cmd_value(thrust4_index, this->thruster_thrusts[3]);
 
     constexpr auto orientation_x_index =
-        suc_util::get_index("imu/imu/orientation_raw.x", state_interface_names);
+        suc_util::get_index("imu/imu/orientation_raw.x", STATE_INTERFACE_NAMES);
     constexpr auto orientation_y_index =
-        suc_util::get_index("imu/imu/orientation_raw.y", state_interface_names);
+        suc_util::get_index("imu/imu/orientation_raw.y", STATE_INTERFACE_NAMES);
     constexpr auto orientation_z_index =
-        suc_util::get_index("imu/imu/orientation_raw.z", state_interface_names);
+        suc_util::get_index("imu/imu/orientation_raw.z", STATE_INTERFACE_NAMES);
     constexpr auto velocity_x_index =
-        suc_util::get_index("imu/imu/velocity_raw.x", state_interface_names);
+        suc_util::get_index("imu/imu/velocity_raw.x", STATE_INTERFACE_NAMES);
     constexpr auto velocity_y_index =
-        suc_util::get_index("imu/imu/velocity_raw.y", state_interface_names);
+        suc_util::get_index("imu/imu/velocity_raw.y", STATE_INTERFACE_NAMES);
     constexpr auto velocity_z_index =
-        suc_util::get_index("imu/imu/velocity_raw.z", state_interface_names);
+        suc_util::get_index("imu/imu/velocity_raw.z", STATE_INTERFACE_NAMES);
 
     this->interface_helper_->get_state_value(orientation_x_index, this->imu_orientation.x);
     this->interface_helper_->get_state_value(orientation_y_index, this->imu_orientation.y);

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -29,10 +29,9 @@ auto succ::AppController::state_interface_configuration() const -> cif::Interfac
 }
 
 auto succ::AppController::on_init() -> cif::CallbackReturn {
-    this->interface_helper =
-        std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, 8, 6>>(
-            this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
-            this->state_interfaces_, this->STATE_INTERFACE_NAMES);
+    this->interface_helper = std::make_unique<InterfaceAccessHelper<CMD_SIZE, STATE_SIZE>>(
+        this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
+        this->state_interfaces_, this->STATE_INTERFACE_NAMES);
 
     return cif::CallbackReturn::SUCCESS;
 }

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -29,7 +29,7 @@ auto succ::AppController::state_interface_configuration() const -> cif::Interfac
 }
 
 auto succ::AppController::on_init() -> cif::CallbackReturn {
-    this->interface_helper_ =
+    this->interface_helper =
         std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, 8, 6>>(
             this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
             this->state_interfaces_, this->STATE_INTERFACE_NAMES);
@@ -129,14 +129,14 @@ auto succ::AppController::update_and_write_commands(
     constexpr auto thrust4_index =
         suc_util::get_index("thruster_controller4/thrust/thrust", CMD_INTERFACE_NAMES);
 
-    this->interface_helper_->set_cmd_value(angle1_index, this->thruster_angles[0]);
-    this->interface_helper_->set_cmd_value(thrust1_index, this->thruster_thrusts[0]);
-    this->interface_helper_->set_cmd_value(angle2_index, this->thruster_angles[1]);
-    this->interface_helper_->set_cmd_value(thrust2_index, this->thruster_thrusts[1]);
-    this->interface_helper_->set_cmd_value(angle3_index, this->thruster_angles[2]);
-    this->interface_helper_->set_cmd_value(thrust3_index, this->thruster_thrusts[2]);
-    this->interface_helper_->set_cmd_value(angle4_index, this->thruster_angles[3]);
-    this->interface_helper_->set_cmd_value(thrust4_index, this->thruster_thrusts[3]);
+    this->interface_helper->set_cmd_value(angle1_index, this->thruster_angles[0]);
+    this->interface_helper->set_cmd_value(thrust1_index, this->thruster_thrusts[0]);
+    this->interface_helper->set_cmd_value(angle2_index, this->thruster_angles[1]);
+    this->interface_helper->set_cmd_value(thrust2_index, this->thruster_thrusts[1]);
+    this->interface_helper->set_cmd_value(angle3_index, this->thruster_angles[2]);
+    this->interface_helper->set_cmd_value(thrust3_index, this->thruster_thrusts[2]);
+    this->interface_helper->set_cmd_value(angle4_index, this->thruster_angles[3]);
+    this->interface_helper->set_cmd_value(thrust4_index, this->thruster_thrusts[3]);
 
     constexpr auto orientation_x_index =
         suc_util::get_index("imu/imu/orientation_raw.x", STATE_INTERFACE_NAMES);
@@ -151,12 +151,12 @@ auto succ::AppController::update_and_write_commands(
     constexpr auto velocity_z_index =
         suc_util::get_index("imu/imu/velocity_raw.z", STATE_INTERFACE_NAMES);
 
-    this->interface_helper_->get_state_value(orientation_x_index, this->imu_orientation.x);
-    this->interface_helper_->get_state_value(orientation_y_index, this->imu_orientation.y);
-    this->interface_helper_->get_state_value(orientation_z_index, this->imu_orientation.z);
-    this->interface_helper_->get_state_value(velocity_x_index, this->imu_velocity.x);
-    this->interface_helper_->get_state_value(velocity_y_index, this->imu_velocity.y);
-    this->interface_helper_->get_state_value(velocity_z_index, this->imu_velocity.z);
+    this->interface_helper->get_state_value(orientation_x_index, this->imu_orientation.x);
+    this->interface_helper->get_state_value(orientation_y_index, this->imu_orientation.y);
+    this->interface_helper->get_state_value(orientation_z_index, this->imu_orientation.z);
+    this->interface_helper->get_state_value(velocity_x_index, this->imu_velocity.x);
+    this->interface_helper->get_state_value(velocity_y_index, this->imu_velocity.y);
+    this->interface_helper->get_state_value(velocity_z_index, this->imu_velocity.z);
 
     return cif::return_type::OK;
 }

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -109,7 +109,34 @@ auto succ::AppController::update_reference_from_subscribers(
 
 auto succ::AppController::update_and_write_commands(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) -> cif::return_type {
-    // TODO: メンバ変数を`target_orientation`と`target_velocity`のinterfaceにセットする
+    // 姿勢制御の関数を呼び出す
+    this->compute_outputs();
+
+    constexpr auto angle1_index =
+        suc_util::get_index("thruster_controller1/angle/angle", cmd_interface_names);
+    constexpr auto thrust1_index =
+        suc_util::get_index("thruster_controller1/thrust/thrust", cmd_interface_names);
+    constexpr auto angle2_index =
+        suc_util::get_index("thruster_controller2/angle/angle", cmd_interface_names);
+    constexpr auto thrust2_index =
+        suc_util::get_index("thruster_controller2/thrust/thrust", cmd_interface_names);
+    constexpr auto angle3_index =
+        suc_util::get_index("thruster_controller3/angle/angle", cmd_interface_names);
+    constexpr auto thrust3_index =
+        suc_util::get_index("thruster_controller3/thrust/thrust", cmd_interface_names);
+    constexpr auto angle4_index =
+        suc_util::get_index("thruster_controller4/angle/angle", cmd_interface_names);
+    constexpr auto thrust4_index =
+        suc_util::get_index("thruster_controller4/thrust/thrust", cmd_interface_names);
+
+    this->interface_helper_->set_cmd_value(angle1_index, this->thruster_angles[0]);
+    this->interface_helper_->set_cmd_value(thrust1_index, this->thruster_thrusts[0]);
+    this->interface_helper_->set_cmd_value(angle2_index, this->thruster_angles[1]);
+    this->interface_helper_->set_cmd_value(thrust2_index, this->thruster_thrusts[1]);
+    this->interface_helper_->set_cmd_value(angle3_index, this->thruster_angles[2]);
+    this->interface_helper_->set_cmd_value(thrust3_index, this->thruster_thrusts[2]);
+    this->interface_helper_->set_cmd_value(angle4_index, this->thruster_angles[3]);
+    this->interface_helper_->set_cmd_value(thrust4_index, this->thruster_thrusts[3]);
 
     constexpr auto orientation_x_index =
         suc_util::get_index("imu/imu/orientation_raw.x", state_interface_names);
@@ -132,6 +159,15 @@ auto succ::AppController::update_and_write_commands(
     this->interface_helper_->get_state_value(velocity_z_index, this->imu_velocity.z);
 
     return cif::return_type::OK;
+}
+
+auto succ::AppController::compute_outputs() -> void {
+    // TODO: PID制御などの処理はここに記述する
+    // 現在はダミー
+    for (size_t i = 0; i < 4; ++i) {
+        this->thruster_angles[i].value = 0.0;
+        this->thruster_thrusts[i].value = 0.0;
+    }
 }
 
 #include "pluginlib/class_list_macros.hpp"

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -138,25 +138,25 @@ auto succ::AppController::update_and_write_commands(
     this->interface_helper->set_cmd_value(ANGLE4_INDEX, this->thruster_angles[3]);
     this->interface_helper->set_cmd_value(THRUST4_INDEX, this->thruster_thrusts[3]);
 
-    constexpr auto orientation_x_index =
+    constexpr auto ORIENTATION_X_INDEX =
         suc_util::get_index("imu/imu/orientation_raw.x", STATE_INTERFACE_NAMES);
-    constexpr auto orientation_y_index =
+    constexpr auto ORIENTATION_Y_INDEX =
         suc_util::get_index("imu/imu/orientation_raw.y", STATE_INTERFACE_NAMES);
-    constexpr auto orientation_z_index =
+    constexpr auto ORIENTATION_Z_INDEX =
         suc_util::get_index("imu/imu/orientation_raw.z", STATE_INTERFACE_NAMES);
-    constexpr auto velocity_x_index =
+    constexpr auto VELOCITY_X_INDEX =
         suc_util::get_index("imu/imu/velocity_raw.x", STATE_INTERFACE_NAMES);
-    constexpr auto velocity_y_index =
+    constexpr auto VELOCITY_Y_INDEX =
         suc_util::get_index("imu/imu/velocity_raw.y", STATE_INTERFACE_NAMES);
-    constexpr auto velocity_z_index =
+    constexpr auto VELOCITY_Z_INDEX =
         suc_util::get_index("imu/imu/velocity_raw.z", STATE_INTERFACE_NAMES);
 
-    this->interface_helper->get_state_value(orientation_x_index, this->imu_orientation.x);
-    this->interface_helper->get_state_value(orientation_y_index, this->imu_orientation.y);
-    this->interface_helper->get_state_value(orientation_z_index, this->imu_orientation.z);
-    this->interface_helper->get_state_value(velocity_x_index, this->imu_velocity.x);
-    this->interface_helper->get_state_value(velocity_y_index, this->imu_velocity.y);
-    this->interface_helper->get_state_value(velocity_z_index, this->imu_velocity.z);
+    this->interface_helper->get_state_value(ORIENTATION_X_INDEX, this->imu_orientation.x);
+    this->interface_helper->get_state_value(ORIENTATION_Y_INDEX, this->imu_orientation.y);
+    this->interface_helper->get_state_value(ORIENTATION_Z_INDEX, this->imu_orientation.z);
+    this->interface_helper->get_state_value(VELOCITY_X_INDEX, this->imu_velocity.x);
+    this->interface_helper->get_state_value(VELOCITY_Y_INDEX, this->imu_velocity.y);
+    this->interface_helper->get_state_value(VELOCITY_Z_INDEX, this->imu_velocity.z);
 
     return cif::return_type::OK;
 }

--- a/src/sinsei_umiusi_control/controller/app_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/app_controller.cpp
@@ -19,7 +19,14 @@ auto succ::AppController::state_interface_configuration() const -> cif::Interfac
     };
 }
 
-auto succ::AppController::on_init() -> cif::CallbackReturn { return cif::CallbackReturn::SUCCESS; }
+auto succ::AppController::on_init() -> cif::CallbackReturn {
+    this->interface_helper_ =
+        std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>>(
+            this->get_node().get(), this->command_interfaces_, this->cmd_interface_names,
+            this->state_interfaces_, this->state_interface_names);
+
+    return cif::CallbackReturn::SUCCESS;
+}
 
 auto succ::AppController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
@@ -103,6 +110,14 @@ auto succ::AppController::update_reference_from_subscribers(
 
 auto succ::AppController::update_and_write_commands(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) -> cif::return_type {
+    // TODO: メンバ変数を`target_orientation`と`target_velocity`のinterfaceにセットする
+    this->interface_helper_->get_state_value("imu/imu/orientation_raw.x", this->imu_orientation.x);
+    this->interface_helper_->get_state_value("imu/imu/orientation_raw.y", this->imu_orientation.y);
+    this->interface_helper_->get_state_value("imu/imu/orientation_raw.z", this->imu_orientation.z);
+    this->interface_helper_->get_state_value("imu/imu/velocity_raw.x", this->imu_velocity.x);
+    this->interface_helper_->get_state_value("imu/imu/velocity_raw.y", this->imu_velocity.y);
+    this->interface_helper_->get_state_value("imu/imu/velocity_raw.z", this->imu_velocity.z);
+
     return cif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -12,7 +12,7 @@ namespace cif = controller_interface;
 
 auto succ::GateController::command_interface_configuration() const -> cif::InterfaceConfiguration {
     std::vector<std::string> cmd_names(
-        std::begin(this->cmd_interface_names), std::end(this->cmd_interface_names));
+        std::begin(this->CMD_INTERFACE_NAMES), std::end(this->CMD_INTERFACE_NAMES));
 
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
@@ -22,7 +22,7 @@ auto succ::GateController::command_interface_configuration() const -> cif::Inter
 
 auto succ::GateController::state_interface_configuration() const -> cif::InterfaceConfiguration {
     std::vector<std::string> state_names(
-        std::begin(this->state_interface_names), std::end(this->state_interface_names));
+        std::begin(this->STATE_INTERFACE_NAMES), std::end(this->STATE_INTERFACE_NAMES));
 
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
@@ -32,9 +32,9 @@ auto succ::GateController::state_interface_configuration() const -> cif::Interfa
 
 auto succ::GateController::on_init() -> cif::CallbackReturn {
     this->interface_helper_ = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, cmd_size, state_size>>(
-        this->get_node().get(), this->command_interfaces_, this->cmd_interface_names,
-        this->state_interfaces_, this->state_interface_names);
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>(
+        this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
+        this->state_interfaces_, this->STATE_INTERFACE_NAMES);
 
     return cif::CallbackReturn::SUCCESS;
 }
@@ -145,46 +145,46 @@ auto succ::GateController::update(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/
     ) -> cif::return_type {
     constexpr auto indicator_led_enabled_index =
-        suc_util::get_index("indicator_led/indicator_led/enabled", cmd_interface_names);
+        suc_util::get_index("indicator_led/indicator_led/enabled", CMD_INTERFACE_NAMES);
     constexpr auto main_power_enabled_index =
-        suc_util::get_index("main_power/main_power/enabled", cmd_interface_names);
+        suc_util::get_index("main_power/main_power/enabled", CMD_INTERFACE_NAMES);
     constexpr auto led_tape_color_index =
-        suc_util::get_index("led_tape/led_tape/color", cmd_interface_names);
+        suc_util::get_index("led_tape/led_tape/color", CMD_INTERFACE_NAMES);
     constexpr auto high_beam_enabled_index =
-        suc_util::get_index("headlights/headlights/high_beam_enabled", cmd_interface_names);
+        suc_util::get_index("headlights/headlights/high_beam_enabled", CMD_INTERFACE_NAMES);
     constexpr auto low_beam_enabled_index =
-        suc_util::get_index("headlights/headlights/low_beam_enabled", cmd_interface_names);
+        suc_util::get_index("headlights/headlights/low_beam_enabled", CMD_INTERFACE_NAMES);
     constexpr auto ir_enabled_index =
-        suc_util::get_index("headlights/headlights/ir_enabled", cmd_interface_names);
+        suc_util::get_index("headlights/headlights/ir_enabled", CMD_INTERFACE_NAMES);
     // TODO: usb_camera, raspi_camera
     constexpr auto servo1_enabled_index = suc_util::get_index(
-        "thruster_controller1/servo_enabled/servo_enabled", cmd_interface_names);
+        "thruster_controller1/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
     constexpr auto servo2_enabled_index = suc_util::get_index(
-        "thruster_controller2/servo_enabled/servo_enabled", cmd_interface_names);
+        "thruster_controller2/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
     constexpr auto servo3_enabled_index = suc_util::get_index(
-        "thruster_controller3/servo_enabled/servo_enabled", cmd_interface_names);
+        "thruster_controller3/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
     constexpr auto servo4_enabled_index = suc_util::get_index(
-        "thruster_controller4/servo_enabled/servo_enabled", cmd_interface_names);
+        "thruster_controller4/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
     constexpr auto esc1_enabled_index =
-        suc_util::get_index("thruster_controller1/esc_enabled/esc_enabled", cmd_interface_names);
+        suc_util::get_index("thruster_controller1/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
     constexpr auto esc2_enabled_index =
-        suc_util::get_index("thruster_controller2/esc_enabled/esc_enabled", cmd_interface_names);
+        suc_util::get_index("thruster_controller2/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
     constexpr auto esc3_enabled_index =
-        suc_util::get_index("thruster_controller3/esc_enabled/esc_enabled", cmd_interface_names);
+        suc_util::get_index("thruster_controller3/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
     constexpr auto esc4_enabled_index =
-        suc_util::get_index("thruster_controller4/esc_enabled/esc_enabled", cmd_interface_names);
+        suc_util::get_index("thruster_controller4/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
     constexpr auto target_orientation_x_index = suc_util::get_index(
-        "app_controller/target_orientation.x/target_orientation.x", cmd_interface_names);
+        "app_controller/target_orientation.x/target_orientation.x", CMD_INTERFACE_NAMES);
     constexpr auto target_orientation_y_index = suc_util::get_index(
-        "app_controller/target_orientation.y/target_orientation.y", cmd_interface_names);
+        "app_controller/target_orientation.y/target_orientation.y", CMD_INTERFACE_NAMES);
     constexpr auto target_orientation_z_index = suc_util::get_index(
-        "app_controller/target_orientation.z/target_orientation.z", cmd_interface_names);
+        "app_controller/target_orientation.z/target_orientation.z", CMD_INTERFACE_NAMES);
     constexpr auto target_velocity_x_index = suc_util::get_index(
-        "app_controller/target_velocity.x/target_velocity.x", cmd_interface_names);
+        "app_controller/target_velocity.x/target_velocity.x", CMD_INTERFACE_NAMES);
     constexpr auto target_velocity_y_index = suc_util::get_index(
-        "app_controller/target_velocity.y/target_velocity.y", cmd_interface_names);
+        "app_controller/target_velocity.y/target_velocity.y", CMD_INTERFACE_NAMES);
     constexpr auto target_velocity_z_index = suc_util::get_index(
-        "app_controller/target_velocity.z/target_velocity.z", cmd_interface_names);
+        "app_controller/target_velocity.z/target_velocity.z", CMD_INTERFACE_NAMES);
 
     this->interface_helper_->set_cmd_value(
         indicator_led_enabled_index, this->indicator_led_enabled_ref);

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -31,8 +31,7 @@ auto succ::GateController::state_interface_configuration() const -> cif::Interfa
 }
 
 auto succ::GateController::on_init() -> cif::CallbackReturn {
-    this->interface_helper = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>(
+    this->interface_helper = std::make_unique<InterfaceAccessHelper<CMD_SIZE, STATE_SIZE>>(
         this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
         this->state_interfaces_, this->STATE_INTERFACE_NAMES);
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -8,59 +8,14 @@ namespace cif = controller_interface;
 auto succ::GateController::command_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        {
-            "indicator_led/indicator_led/enabled",
-            "main_power/main_power/enabled",
-            "led_tape/led_tape/color",
-            "headlights/headlights/high_beam_enabled",
-            "headlights/headlights/low_beam_enabled",
-            "headlights/headlights/ir_enabled",
-            "usb_camera/usb_camera/config",
-            "raspi_camera/raspi_camera/config",
-            "thruster_controller1/servo_enabled/servo_enabled",
-            "thruster_controller2/servo_enabled/servo_enabled",
-            "thruster_controller3/servo_enabled/servo_enabled",
-            "thruster_controller4/servo_enabled/servo_enabled",
-            "thruster_controller1/esc_enabled/esc_enabled",
-            "thruster_controller2/esc_enabled/esc_enabled",
-            "thruster_controller3/esc_enabled/esc_enabled",
-            "thruster_controller4/esc_enabled/esc_enabled",
-            "app_controller/target_orientation.x/target_orientation.x",
-            "app_controller/target_orientation.y/target_orientation.y",
-            "app_controller/target_orientation.z/target_orientation.z",
-            "app_controller/target_velocity.x/target_velocity.x",
-            "app_controller/target_velocity.y/target_velocity.y",
-            "app_controller/target_velocity.z/target_velocity.z",
-        },
+        this->cmd_interface_names,
     };
 }
 
 auto succ::GateController::state_interface_configuration() const -> cif::InterfaceConfiguration {
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        {
-            "main_power/main_power/battery_current",
-            "main_power/main_power/battery_voltage",
-            "main_power/main_power/temperature",
-            "main_power/main_power/water_leaked",
-            "thruster_controller1/servo_current/servo_current",
-            "thruster_controller2/servo_current/servo_current",
-            "thruster_controller3/servo_current/servo_current",
-            "thruster_controller4/servo_current/servo_current",
-            "thruster_controller1/rpm/rpm",
-            "thruster_controller2/rpm/rpm",
-            "thruster_controller3/rpm/rpm",
-            "thruster_controller4/rpm/rpm",
-            "app_controller/imu_orientation.x/imu_orientation.x",
-            "app_controller/imu_orientation.y/imu_orientation.y",
-            "app_controller/imu_orientation.z/imu_orientation.z",
-            "app_controller/imu_velocity.x/imu_velocity.x",
-            "app_controller/imu_velocity.y/imu_velocity.y",
-            "app_controller/imu_velocity.z/imu_velocity.z",
-            "imu/imu/temperature",
-            "usb_camera/usb_camera/image",
-            "raspi_camera/raspi_camera/image",
-        },
+        this->state_interface_names,
     };
 }
 
@@ -68,6 +23,54 @@ auto succ::GateController::on_init() -> cif::CallbackReturn { return cif::Callba
 
 auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
+    this->cmd_interface_names = {
+        "indicator_led/indicator_led/enabled",
+        "main_power/main_power/enabled",
+        "led_tape/led_tape/color",
+        "headlights/headlights/high_beam_enabled",
+        "headlights/headlights/low_beam_enabled",
+        "headlights/headlights/ir_enabled",
+        "usb_camera/usb_camera/config",
+        "raspi_camera/raspi_camera/config",
+        "thruster_controller1/servo_enabled/servo_enabled",
+        "thruster_controller2/servo_enabled/servo_enabled",
+        "thruster_controller3/servo_enabled/servo_enabled",
+        "thruster_controller4/servo_enabled/servo_enabled",
+        "thruster_controller1/esc_enabled/esc_enabled",
+        "thruster_controller2/esc_enabled/esc_enabled",
+        "thruster_controller3/esc_enabled/esc_enabled",
+        "thruster_controller4/esc_enabled/esc_enabled",
+        "app_controller/target_orientation.x/target_orientation.x",
+        "app_controller/target_orientation.y/target_orientation.y",
+        "app_controller/target_orientation.z/target_orientation.z",
+        "app_controller/target_velocity.x/target_velocity.x",
+        "app_controller/target_velocity.y/target_velocity.y",
+        "app_controller/target_velocity.z/target_velocity.z",
+    };
+    this->state_interface_names = {
+        "main_power/main_power/battery_current",
+        "main_power/main_power/battery_voltage",
+        "main_power/main_power/temperature",
+        "main_power/main_power/water_leaked",
+        "thruster_controller1/servo_current/servo_current",
+        "thruster_controller2/servo_current/servo_current",
+        "thruster_controller3/servo_current/servo_current",
+        "thruster_controller4/servo_current/servo_current",
+        "thruster_controller1/rpm/rpm",
+        "thruster_controller2/rpm/rpm",
+        "thruster_controller3/rpm/rpm",
+        "thruster_controller4/rpm/rpm",
+        "app_controller/imu_orientation.x/imu_orientation.x",
+        "app_controller/imu_orientation.y/imu_orientation.y",
+        "app_controller/imu_orientation.z/imu_orientation.z",
+        "app_controller/imu_velocity.x/imu_velocity.x",
+        "app_controller/imu_velocity.y/imu_velocity.y",
+        "app_controller/imu_velocity.z/imu_velocity.z",
+        "imu/imu/temperature",
+        "usb_camera/usb_camera/image",
+        "raspi_camera/raspi_camera/image",
+    };
+
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
     this->indicator_led_enabled_subscriber =
         this->get_node()->create_subscription<std_msgs::msg::Bool>(

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -19,7 +19,14 @@ auto succ::GateController::state_interface_configuration() const -> cif::Interfa
     };
 }
 
-auto succ::GateController::on_init() -> cif::CallbackReturn { return cif::CallbackReturn::SUCCESS; }
+auto succ::GateController::on_init() -> cif::CallbackReturn {
+    this->interface_helper_ =
+        std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>>(
+            this->get_node().get(), this->command_interfaces_, this->cmd_interface_names,
+            this->state_interfaces_, this->state_interface_names);
+
+    return cif::CallbackReturn::SUCCESS;
+}
 
 auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
@@ -95,19 +102,9 @@ auto succ::GateController::update(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/
     ) -> cif::return_type {
     // TODO: 今後`indicator_led/indicator_led/enabled`以外の分も実装する
-    /*if (!this->indicator_led_enabled) {
-        RCLCPP_ERROR(
-            this->get_node()->get_logger(),
-            "Command interface not initialized: indicator_led/indicator_led/enabled");
-        return cif::return_type::ERROR;
-    }
-    auto res = this->indicator_led_enabled->set_value(
+    this->interface_helper_->set_cmd_value(
+        "indicator_led/indicator_led/enabled",
         *reinterpret_cast<double *>(&this->indicator_led_enabled_ref));
-    if (!res) {
-        RCLCPP_WARN(
-            this->get_node()->get_logger(), "Failed to set command interface value: %s",
-            this->indicator_led_enabled->get_name().c_str());
-    }*/
     return cif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -31,7 +31,7 @@ auto succ::GateController::state_interface_configuration() const -> cif::Interfa
 }
 
 auto succ::GateController::on_init() -> cif::CallbackReturn {
-    this->interface_helper_ = std::make_unique<
+    this->interface_helper = std::make_unique<
         InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CMD_SIZE, STATE_SIZE>>(
         this->get_node().get(), this->command_interfaces_, this->CMD_INTERFACE_NAMES,
         this->state_interfaces_, this->STATE_INTERFACE_NAMES);
@@ -186,31 +186,31 @@ auto succ::GateController::update(
     constexpr auto target_velocity_z_index = suc_util::get_index(
         "app_controller/target_velocity.z/target_velocity.z", CMD_INTERFACE_NAMES);
 
-    this->interface_helper_->set_cmd_value(
+    this->interface_helper->set_cmd_value(
         indicator_led_enabled_index, this->indicator_led_enabled_ref);
-    this->interface_helper_->set_cmd_value(main_power_enabled_index, this->main_power_enabled_ref);
-    this->interface_helper_->set_cmd_value(led_tape_color_index, this->led_tape_color_ref);
-    this->interface_helper_->set_cmd_value(high_beam_enabled_index, this->high_beam_enabled_ref);
-    this->interface_helper_->set_cmd_value(low_beam_enabled_index, this->low_beam_enabled_ref);
-    this->interface_helper_->set_cmd_value(ir_enabled_index, this->ir_enabled_ref);
+    this->interface_helper->set_cmd_value(main_power_enabled_index, this->main_power_enabled_ref);
+    this->interface_helper->set_cmd_value(led_tape_color_index, this->led_tape_color_ref);
+    this->interface_helper->set_cmd_value(high_beam_enabled_index, this->high_beam_enabled_ref);
+    this->interface_helper->set_cmd_value(low_beam_enabled_index, this->low_beam_enabled_ref);
+    this->interface_helper->set_cmd_value(ir_enabled_index, this->ir_enabled_ref);
     // TODO: usb_camera, raspi_camera
-    this->interface_helper_->set_cmd_value(servo1_enabled_index, this->servo_enabled_ref);
-    this->interface_helper_->set_cmd_value(servo2_enabled_index, this->servo_enabled_ref);
-    this->interface_helper_->set_cmd_value(servo3_enabled_index, this->servo_enabled_ref);
-    this->interface_helper_->set_cmd_value(servo4_enabled_index, this->servo_enabled_ref);
-    this->interface_helper_->set_cmd_value(esc1_enabled_index, this->esc_enabled_ref);
-    this->interface_helper_->set_cmd_value(esc2_enabled_index, this->esc_enabled_ref);
-    this->interface_helper_->set_cmd_value(esc3_enabled_index, this->esc_enabled_ref);
-    this->interface_helper_->set_cmd_value(esc4_enabled_index, this->esc_enabled_ref);
-    this->interface_helper_->set_cmd_value(
+    this->interface_helper->set_cmd_value(servo1_enabled_index, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(servo2_enabled_index, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(servo3_enabled_index, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(servo4_enabled_index, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(esc1_enabled_index, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(esc2_enabled_index, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(esc3_enabled_index, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(esc4_enabled_index, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(
         target_orientation_x_index, this->target_orientation_ref.x);
-    this->interface_helper_->set_cmd_value(
+    this->interface_helper->set_cmd_value(
         target_orientation_y_index, this->target_orientation_ref.y);
-    this->interface_helper_->set_cmd_value(
+    this->interface_helper->set_cmd_value(
         target_orientation_z_index, this->target_orientation_ref.z);
-    this->interface_helper_->set_cmd_value(target_velocity_x_index, this->target_velocity_ref.x);
-    this->interface_helper_->set_cmd_value(target_velocity_y_index, this->target_velocity_ref.y);
-    this->interface_helper_->set_cmd_value(target_velocity_z_index, this->target_velocity_ref.z);
+    this->interface_helper->set_cmd_value(target_velocity_x_index, this->target_velocity_ref.x);
+    this->interface_helper->set_cmd_value(target_velocity_y_index, this->target_velocity_ref.y);
+    this->interface_helper->set_cmd_value(target_velocity_z_index, this->target_velocity_ref.z);
 
     this->battery_current_publisher->publish(
         std_msgs::msg::Float64().set__data(this->battery_current_ref.value));

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -144,73 +144,73 @@ auto succ::GateController::on_deactivate(const rlc::State & /*previous_state*/)
 auto succ::GateController::update(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/
     ) -> cif::return_type {
-    constexpr auto indicator_led_enabled_index =
+    constexpr auto INDICATOR_LED_ENABLED_INDEX =
         suc_util::get_index("indicator_led/indicator_led/enabled", CMD_INTERFACE_NAMES);
-    constexpr auto main_power_enabled_index =
+    constexpr auto MAIN_POWER_ENABLED_INDEX =
         suc_util::get_index("main_power/main_power/enabled", CMD_INTERFACE_NAMES);
-    constexpr auto led_tape_color_index =
+    constexpr auto LED_TAPE_COLOR_INDEX =
         suc_util::get_index("led_tape/led_tape/color", CMD_INTERFACE_NAMES);
-    constexpr auto high_beam_enabled_index =
+    constexpr auto HIGH_BEAM_ENABLED_INDEX =
         suc_util::get_index("headlights/headlights/high_beam_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto low_beam_enabled_index =
+    constexpr auto LOW_BEAM_ENABLED_INDEX =
         suc_util::get_index("headlights/headlights/low_beam_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto ir_enabled_index =
+    constexpr auto IR_ENABLED_INDEX =
         suc_util::get_index("headlights/headlights/ir_enabled", CMD_INTERFACE_NAMES);
     // TODO: usb_camera, raspi_camera
-    constexpr auto servo1_enabled_index = suc_util::get_index(
+    constexpr auto SERVO1_ENABLED_INDEX = suc_util::get_index(
         "thruster_controller1/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto servo2_enabled_index = suc_util::get_index(
+    constexpr auto SERVO2_ENABLED_INDEX = suc_util::get_index(
         "thruster_controller2/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto servo3_enabled_index = suc_util::get_index(
+    constexpr auto SERVO3_ENABLED_INDEX = suc_util::get_index(
         "thruster_controller3/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto servo4_enabled_index = suc_util::get_index(
+    constexpr auto SERVO4_ENABLED_INDEX = suc_util::get_index(
         "thruster_controller4/servo_enabled/servo_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto esc1_enabled_index =
+    constexpr auto ESC1_ENABLED_INDEX =
         suc_util::get_index("thruster_controller1/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto esc2_enabled_index =
+    constexpr auto ESC2_ENABLED_INDEX =
         suc_util::get_index("thruster_controller2/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto esc3_enabled_index =
+    constexpr auto ESC3_ENABLED_INDEX =
         suc_util::get_index("thruster_controller3/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto esc4_enabled_index =
+    constexpr auto ESC4_ENABLED_INDEX =
         suc_util::get_index("thruster_controller4/esc_enabled/esc_enabled", CMD_INTERFACE_NAMES);
-    constexpr auto target_orientation_x_index = suc_util::get_index(
+    constexpr auto TARGET_ORIENTATION_X_INDEX = suc_util::get_index(
         "app_controller/target_orientation.x/target_orientation.x", CMD_INTERFACE_NAMES);
-    constexpr auto target_orientation_y_index = suc_util::get_index(
+    constexpr auto TARGET_ORIENTATION_Y_INDEX = suc_util::get_index(
         "app_controller/target_orientation.y/target_orientation.y", CMD_INTERFACE_NAMES);
-    constexpr auto target_orientation_z_index = suc_util::get_index(
+    constexpr auto TARGET_ORIENTATION_Z_INDEX = suc_util::get_index(
         "app_controller/target_orientation.z/target_orientation.z", CMD_INTERFACE_NAMES);
-    constexpr auto target_velocity_x_index = suc_util::get_index(
+    constexpr auto TARGET_VELOCITY_X_INDEX = suc_util::get_index(
         "app_controller/target_velocity.x/target_velocity.x", CMD_INTERFACE_NAMES);
-    constexpr auto target_velocity_y_index = suc_util::get_index(
+    constexpr auto TARGET_VELOCITY_Y_INDEX = suc_util::get_index(
         "app_controller/target_velocity.y/target_velocity.y", CMD_INTERFACE_NAMES);
-    constexpr auto target_velocity_z_index = suc_util::get_index(
+    constexpr auto TARGET_VELOCITY_Z_INDEX = suc_util::get_index(
         "app_controller/target_velocity.z/target_velocity.z", CMD_INTERFACE_NAMES);
 
     this->interface_helper->set_cmd_value(
-        indicator_led_enabled_index, this->indicator_led_enabled_ref);
-    this->interface_helper->set_cmd_value(main_power_enabled_index, this->main_power_enabled_ref);
-    this->interface_helper->set_cmd_value(led_tape_color_index, this->led_tape_color_ref);
-    this->interface_helper->set_cmd_value(high_beam_enabled_index, this->high_beam_enabled_ref);
-    this->interface_helper->set_cmd_value(low_beam_enabled_index, this->low_beam_enabled_ref);
-    this->interface_helper->set_cmd_value(ir_enabled_index, this->ir_enabled_ref);
+        INDICATOR_LED_ENABLED_INDEX, this->indicator_led_enabled_ref);
+    this->interface_helper->set_cmd_value(MAIN_POWER_ENABLED_INDEX, this->main_power_enabled_ref);
+    this->interface_helper->set_cmd_value(LED_TAPE_COLOR_INDEX, this->led_tape_color_ref);
+    this->interface_helper->set_cmd_value(HIGH_BEAM_ENABLED_INDEX, this->high_beam_enabled_ref);
+    this->interface_helper->set_cmd_value(LOW_BEAM_ENABLED_INDEX, this->low_beam_enabled_ref);
+    this->interface_helper->set_cmd_value(IR_ENABLED_INDEX, this->ir_enabled_ref);
     // TODO: usb_camera, raspi_camera
-    this->interface_helper->set_cmd_value(servo1_enabled_index, this->servo_enabled_ref);
-    this->interface_helper->set_cmd_value(servo2_enabled_index, this->servo_enabled_ref);
-    this->interface_helper->set_cmd_value(servo3_enabled_index, this->servo_enabled_ref);
-    this->interface_helper->set_cmd_value(servo4_enabled_index, this->servo_enabled_ref);
-    this->interface_helper->set_cmd_value(esc1_enabled_index, this->esc_enabled_ref);
-    this->interface_helper->set_cmd_value(esc2_enabled_index, this->esc_enabled_ref);
-    this->interface_helper->set_cmd_value(esc3_enabled_index, this->esc_enabled_ref);
-    this->interface_helper->set_cmd_value(esc4_enabled_index, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(SERVO1_ENABLED_INDEX, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(SERVO2_ENABLED_INDEX, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(SERVO3_ENABLED_INDEX, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(SERVO4_ENABLED_INDEX, this->servo_enabled_ref);
+    this->interface_helper->set_cmd_value(ESC1_ENABLED_INDEX, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(ESC2_ENABLED_INDEX, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(ESC3_ENABLED_INDEX, this->esc_enabled_ref);
+    this->interface_helper->set_cmd_value(ESC4_ENABLED_INDEX, this->esc_enabled_ref);
     this->interface_helper->set_cmd_value(
-        target_orientation_x_index, this->target_orientation_ref.x);
+        TARGET_ORIENTATION_X_INDEX, this->target_orientation_ref.x);
     this->interface_helper->set_cmd_value(
-        target_orientation_y_index, this->target_orientation_ref.y);
+        TARGET_ORIENTATION_Y_INDEX, this->target_orientation_ref.y);
     this->interface_helper->set_cmd_value(
-        target_orientation_z_index, this->target_orientation_ref.z);
-    this->interface_helper->set_cmd_value(target_velocity_x_index, this->target_velocity_ref.x);
-    this->interface_helper->set_cmd_value(target_velocity_y_index, this->target_velocity_ref.y);
-    this->interface_helper->set_cmd_value(target_velocity_z_index, this->target_velocity_ref.z);
+        TARGET_ORIENTATION_Z_INDEX, this->target_orientation_ref.z);
+    this->interface_helper->set_cmd_value(TARGET_VELOCITY_X_INDEX, this->target_velocity_ref.x);
+    this->interface_helper->set_cmd_value(TARGET_VELOCITY_Y_INDEX, this->target_velocity_ref.y);
+    this->interface_helper->set_cmd_value(TARGET_VELOCITY_Z_INDEX, this->target_velocity_ref.z);
 
     this->battery_current_publisher->publish(
         std_msgs::msg::Float64().set__data(this->battery_current_ref.value));

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -15,11 +15,9 @@ auto succ::ThrusterController::command_interface_configuration() const
 
 auto succ::ThrusterController::state_interface_configuration() const
     -> cif::InterfaceConfiguration {
-    std::vector<std::string> interface_names;
-
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        interface_names,
+        this->state_interface_names,
     };
 }
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -20,6 +20,7 @@ auto succ::ThrusterController::command_interface_configuration() const
             std::end(this->direct_cmd_interface_names));
     }
 
+    // リストではスラスタ名が省略されているため、ここで付与する
     std::string prefix = (this->mode == ThrusterMode::Can ? "thruster" : "thruster_direct") +
                          std::to_string(this->id);
     for (auto & name : cmd_names) {
@@ -42,6 +43,7 @@ auto succ::ThrusterController::state_interface_configuration() const
         state_names = {};
     }
 
+    // リストではスラスタ名が省略されているため、ここで付与する
     std::string prefix = (this->mode == ThrusterMode::Can ? "thruster" : "thruster_direct") +
                          std::to_string(this->id);
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -7,28 +7,9 @@ namespace cif = controller_interface;
 
 auto succ::ThrusterController::command_interface_configuration() const
     -> cif::InterfaceConfiguration {
-    std::vector<std::string> interface_names;
-    std::string id_str = std::to_string(this->id);
-
-    if (this->mode == ThrusterMode::Can) {
-        interface_names = {
-            "thruster" + id_str + "/servo/servo/enabled_raw",
-            "thruster" + id_str + "/servo/servo/angle_raw",
-            "thruster" + id_str + "/esc/esc/enabled_raw",
-            "thruster" + id_str + "/esc/esc/thrust_raw",
-        };
-    } else if (this->mode == ThrusterMode::Direct) {
-        interface_names = {
-            "thruster_direct" + id_str + "/servo_direct/servo_direct/enabled_raw",
-            "thruster_direct" + id_str + "/servo_direct/servo_direct/angle_raw",
-            "thruster_direct" + id_str + "/esc_direct/esc_direct/enabled_raw",
-            "thruster_direct" + id_str + "/esc_direct/esc_direct/thrust_raw",
-        };
-    }
-
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
-        interface_names,
+        this->cmd_interface_names,
     };
 }
 
@@ -36,13 +17,6 @@ auto succ::ThrusterController::state_interface_configuration() const
     -> cif::InterfaceConfiguration {
     std::vector<std::string> interface_names;
 
-    std::string id_str = std::to_string(this->id);
-    if (this->mode == ThrusterMode::Can) {
-        interface_names = {
-            "thruster" + id_str + "/servo/servo/servo_current_raw",
-            "thruster" + id_str + "/esc/esc/rpm_raw",
-        };
-    }
     return cif::InterfaceConfiguration{
         cif::interface_configuration_type::INDIVIDUAL,
         interface_names,
@@ -70,6 +44,27 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
 
 auto succ::ThrusterController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
+    std::string id_str = std::to_string(this->id);
+
+    if (this->mode == ThrusterMode::Can) {
+        this->cmd_interface_names = {
+            "thruster" + id_str + "/servo/servo/enabled_raw",
+            "thruster" + id_str + "/servo/servo/angle_raw",
+            "thruster" + id_str + "/esc/esc/enabled_raw",
+            "thruster" + id_str + "/esc/esc/thrust_raw",
+        };
+        this->state_interface_names = {
+            "thruster" + id_str + "/servo/servo/servo_current_raw",
+            "thruster" + id_str + "/esc/esc/rpm_raw",
+        };
+    } else if (this->mode == ThrusterMode::Direct) {
+        this->cmd_interface_names = {
+            "thruster_direct" + id_str + "/servo_direct/servo_direct/enabled_raw",
+            "thruster_direct" + id_str + "/servo_direct/servo_direct/angle_raw",
+            "thruster_direct" + id_str + "/esc_direct/esc_direct/enabled_raw",
+            "thruster_direct" + id_str + "/esc_direct/esc_direct/thrust_raw",
+        };
+    }
     return cif::CallbackReturn::SUCCESS;
 }
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -142,41 +142,42 @@ auto succ::ThrusterController::update_reference_from_subscribers(
 auto succ::ThrusterController::update_and_write_commands(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) -> cif::return_type {
     if (this->mode == ThrusterMode::Can) {
-        constexpr auto servo_enabled_index =
+        constexpr auto SERVO_ENABLED_INDEX =
             suc_util::get_index("servo/servo/enabled_raw", CAN_CMD_INTERFACE_NAMES);
-        constexpr auto angle_index =
+        constexpr auto ANGLE_INDEX =
             suc_util::get_index("servo/servo/angle_raw", CAN_CMD_INTERFACE_NAMES);
-        constexpr auto esc_enabled_index =
+        constexpr auto ESC_ENABLED_INDEX =
             suc_util::get_index("esc/esc/enabled_raw", CAN_CMD_INTERFACE_NAMES);
-        constexpr auto thrust_index =
+        constexpr auto THRUST_INDEX =
             suc_util::get_index("esc/esc/thrust_raw", CAN_CMD_INTERFACE_NAMES);
 
-        constexpr auto servo_current_index =
+        constexpr auto SERVO_CURRENT_INDEX =
             suc_util::get_index("servo/servo/servo_current_raw", CAN_STATE_INTERFACE_NAMES);
-        constexpr auto rpm_index =
+        constexpr auto RPM_INDEX =
             suc_util::get_index("esc/esc/rpm_raw", CAN_STATE_INTERFACE_NAMES);
 
-        this->can_interface_helper->set_cmd_value(servo_enabled_index, this->servo_enabled);
-        this->can_interface_helper->set_cmd_value(angle_index, this->angle);
-        this->can_interface_helper->set_cmd_value(esc_enabled_index, this->esc_enabled);
-        this->can_interface_helper->set_cmd_value(thrust_index, this->thrust);
+        this->can_interface_helper->set_cmd_value(SERVO_ENABLED_INDEX, this->servo_enabled);
+        this->can_interface_helper->set_cmd_value(ANGLE_INDEX, this->angle);
+        this->can_interface_helper->set_cmd_value(ESC_ENABLED_INDEX, this->esc_enabled);
+        this->can_interface_helper->set_cmd_value(THRUST_INDEX, this->thrust);
 
-        this->can_interface_helper->get_state_value(servo_current_index, this->servo_current);
-        this->can_interface_helper->get_state_value(rpm_index, this->rpm);
+        this->can_interface_helper->get_state_value(SERVO_CURRENT_INDEX, this->servo_current);
+        this->can_interface_helper->get_state_value(RPM_INDEX, this->rpm);
+
     } else {
-        constexpr auto servo_enabled_index = suc_util::get_index(
+        constexpr auto SERVO_ENABLED_INDEX = suc_util::get_index(
             "servo_direct/servo_direct/enabled_raw", DIRECT_CMD_INTERFACE_NAMES);
-        constexpr auto angle_index =
+        constexpr auto ANGLE_INDEX =
             suc_util::get_index("servo_direct/servo_direct/angle_raw", DIRECT_CMD_INTERFACE_NAMES);
-        constexpr auto esc_enabled_index =
+        constexpr auto ESC_ENABLED_INDEX =
             suc_util::get_index("esc_direct/esc_direct/enabled_raw", DIRECT_CMD_INTERFACE_NAMES);
-        constexpr auto thrust_index =
+        constexpr auto THRUST_INDEX =
             suc_util::get_index("esc_direct/esc_direct/thrust_raw", DIRECT_CMD_INTERFACE_NAMES);
 
-        this->direct_interface_helper->set_cmd_value(servo_enabled_index, this->servo_enabled);
-        this->direct_interface_helper->set_cmd_value(angle_index, this->angle);
-        this->direct_interface_helper->set_cmd_value(esc_enabled_index, this->esc_enabled);
-        this->direct_interface_helper->set_cmd_value(thrust_index, this->thrust);
+        this->direct_interface_helper->set_cmd_value(SERVO_ENABLED_INDEX, this->servo_enabled);
+        this->direct_interface_helper->set_cmd_value(ANGLE_INDEX, this->angle);
+        this->direct_interface_helper->set_cmd_value(ESC_ENABLED_INDEX, this->esc_enabled);
+        this->direct_interface_helper->set_cmd_value(THRUST_INDEX, this->thrust);
     }
 
     return cif::return_type::OK;

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -37,6 +37,11 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
         return cif::CallbackReturn::ERROR;
     }
 
+    this->interface_helper_ =
+        std::make_unique<InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode>>(
+            this->get_node().get(), this->command_interfaces_, this->cmd_interface_names,
+            this->state_interfaces_, this->state_interface_names);
+
     return cif::CallbackReturn::SUCCESS;
 }
 
@@ -117,6 +122,35 @@ auto succ::ThrusterController::update_reference_from_subscribers(
 
 auto succ::ThrusterController::update_and_write_commands(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) -> cif::return_type {
+    bool is_can = this->mode == ThrusterMode::Can;
+
+    std::string hw_name = is_can ? "thruster" + std::to_string(this->id)
+                                 : "thruster_direct" + std::to_string(this->id);
+    std::string esc_gpio = is_can ? "esc" : "esc_direct";
+    std::string servo_gpio = is_can ? "servo" : "servo_direct";
+
+    // Set command interfaces
+    this->interface_helper_->set_cmd_value(
+        hw_name + "/" + servo_gpio + "/" + servo_gpio + "/enabled_raw",
+        *reinterpret_cast<double *>(&this->servo_enabled));
+    this->interface_helper_->set_cmd_value(
+        hw_name + "/" + servo_gpio + "/" + servo_gpio + "/angle_raw",
+        *reinterpret_cast<double *>(&this->angle));
+    this->interface_helper_->set_cmd_value(
+        hw_name + "/" + esc_gpio + "/" + esc_gpio + "/enabled_raw",
+        *reinterpret_cast<double *>(&this->esc_enabled));
+    this->interface_helper_->set_cmd_value(
+        hw_name + "/" + esc_gpio + "/" + esc_gpio + "/thrust_raw",
+        *reinterpret_cast<double *>(&this->thrust));
+    // Set state interfaces
+    if (is_can) {
+        this->interface_helper_->get_state_value(
+            hw_name + "/" + servo_gpio + "/" + servo_gpio + "/servo_current_raw",
+            this->servo_current);
+        this->interface_helper_->get_state_value(
+            hw_name + "/" + esc_gpio + "/" + esc_gpio + "/rpm_raw", this->rpm);
+    }
+
     return cif::return_type::OK;
 }
 

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -73,11 +73,11 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
         return cif::CallbackReturn::ERROR;
     }
 
-    this->can_interface_helper_ = std::make_unique<
+    this->can_interface_helper = std::make_unique<
         InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>(
         this->get_node().get(), this->command_interfaces_, this->CAN_CMD_INTERFACE_NAMES,
         this->state_interfaces_, this->CAN_STATE_INTERFACE_NAMES);
-    this->direct_interface_helper_ = std::make_unique<
+    this->direct_interface_helper = std::make_unique<
         InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>(
         this->get_node().get(), this->command_interfaces_, this->DIRECT_CMD_INTERFACE_NAMES,
         this->state_interfaces_, this->DIRECT_STATE_INTERFACE_NAMES);
@@ -156,13 +156,13 @@ auto succ::ThrusterController::update_and_write_commands(
         constexpr auto rpm_index =
             suc_util::get_index("esc/esc/rpm_raw", CAN_STATE_INTERFACE_NAMES);
 
-        this->can_interface_helper_->set_cmd_value(servo_enabled_index, this->servo_enabled);
-        this->can_interface_helper_->set_cmd_value(angle_index, this->angle);
-        this->can_interface_helper_->set_cmd_value(esc_enabled_index, this->esc_enabled);
-        this->can_interface_helper_->set_cmd_value(thrust_index, this->thrust);
+        this->can_interface_helper->set_cmd_value(servo_enabled_index, this->servo_enabled);
+        this->can_interface_helper->set_cmd_value(angle_index, this->angle);
+        this->can_interface_helper->set_cmd_value(esc_enabled_index, this->esc_enabled);
+        this->can_interface_helper->set_cmd_value(thrust_index, this->thrust);
 
-        this->can_interface_helper_->get_state_value(servo_current_index, this->servo_current);
-        this->can_interface_helper_->get_state_value(rpm_index, this->rpm);
+        this->can_interface_helper->get_state_value(servo_current_index, this->servo_current);
+        this->can_interface_helper->get_state_value(rpm_index, this->rpm);
     } else {
         constexpr auto servo_enabled_index = suc_util::get_index(
             "servo_direct/servo_direct/enabled_raw", DIRECT_CMD_INTERFACE_NAMES);
@@ -173,10 +173,10 @@ auto succ::ThrusterController::update_and_write_commands(
         constexpr auto thrust_index =
             suc_util::get_index("esc_direct/esc_direct/thrust_raw", DIRECT_CMD_INTERFACE_NAMES);
 
-        this->direct_interface_helper_->set_cmd_value(servo_enabled_index, this->servo_enabled);
-        this->direct_interface_helper_->set_cmd_value(angle_index, this->angle);
-        this->direct_interface_helper_->set_cmd_value(esc_enabled_index, this->esc_enabled);
-        this->direct_interface_helper_->set_cmd_value(thrust_index, this->thrust);
+        this->direct_interface_helper->set_cmd_value(servo_enabled_index, this->servo_enabled);
+        this->direct_interface_helper->set_cmd_value(angle_index, this->angle);
+        this->direct_interface_helper->set_cmd_value(esc_enabled_index, this->esc_enabled);
+        this->direct_interface_helper->set_cmd_value(thrust_index, this->thrust);
     }
 
     return cif::return_type::OK;

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -73,14 +73,14 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
         return cif::CallbackReturn::ERROR;
     }
 
-    this->can_interface_helper = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>(
-        this->get_node().get(), this->command_interfaces_, this->CAN_CMD_INTERFACE_NAMES,
-        this->state_interfaces_, this->CAN_STATE_INTERFACE_NAMES);
-    this->direct_interface_helper = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>(
-        this->get_node().get(), this->command_interfaces_, this->DIRECT_CMD_INTERFACE_NAMES,
-        this->state_interfaces_, this->DIRECT_STATE_INTERFACE_NAMES);
+    this->can_interface_helper =
+        std::make_unique<InterfaceAccessHelper<CAN_CMD_SIZE, CAN_STATE_SIZE>>(
+            this->get_node().get(), this->command_interfaces_, this->CAN_CMD_INTERFACE_NAMES,
+            this->state_interfaces_, this->CAN_STATE_INTERFACE_NAMES);
+    this->direct_interface_helper =
+        std::make_unique<InterfaceAccessHelper<DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>(
+            this->get_node().get(), this->command_interfaces_, this->DIRECT_CMD_INTERFACE_NAMES,
+            this->state_interfaces_, this->DIRECT_STATE_INTERFACE_NAMES);
 
     return cif::CallbackReturn::SUCCESS;
 }

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -13,11 +13,11 @@ auto succ::ThrusterController::command_interface_configuration() const
     std::vector<std::string> cmd_names;
     if (this->mode == ThrusterMode::Can) {
         cmd_names.assign(
-            std::begin(this->can_cmd_interface_names), std::end(this->can_cmd_interface_names));
+            std::begin(this->CAN_CMD_INTERFACE_NAMES), std::end(this->CAN_CMD_INTERFACE_NAMES));
     } else {
         cmd_names.assign(
-            std::begin(this->direct_cmd_interface_names),
-            std::end(this->direct_cmd_interface_names));
+            std::begin(this->DIRECT_CMD_INTERFACE_NAMES),
+            std::end(this->DIRECT_CMD_INTERFACE_NAMES));
     }
 
     // リストではスラスタ名が省略されているため、ここで付与する
@@ -38,7 +38,7 @@ auto succ::ThrusterController::state_interface_configuration() const
     std::vector<std::string> state_names;
     if (this->mode == ThrusterMode::Can) {
         state_names.assign(
-            std::begin(this->can_state_interface_names), std::end(this->can_state_interface_names));
+            std::begin(this->CAN_STATE_INTERFACE_NAMES), std::end(this->CAN_STATE_INTERFACE_NAMES));
     } else {
         state_names = {};
     }
@@ -74,13 +74,13 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
     }
 
     this->can_interface_helper_ = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, can_cmd_size, can_state_size>>(
-        this->get_node().get(), this->command_interfaces_, this->can_cmd_interface_names,
-        this->state_interfaces_, this->can_state_interface_names);
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, CAN_CMD_SIZE, CAN_STATE_SIZE>>(
+        this->get_node().get(), this->command_interfaces_, this->CAN_CMD_INTERFACE_NAMES,
+        this->state_interfaces_, this->CAN_STATE_INTERFACE_NAMES);
     this->direct_interface_helper_ = std::make_unique<
-        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, direct_cmd_size, direct_state_size>>(
-        this->get_node().get(), this->command_interfaces_, this->direct_cmd_interface_names,
-        this->state_interfaces_, this->direct_state_interface_names);
+        InterfaceAccessHelper<rclcpp_lifecycle::LifecycleNode, DIRECT_CMD_SIZE, DIRECT_STATE_SIZE>>(
+        this->get_node().get(), this->command_interfaces_, this->DIRECT_CMD_INTERFACE_NAMES,
+        this->state_interfaces_, this->DIRECT_STATE_INTERFACE_NAMES);
 
     return cif::CallbackReturn::SUCCESS;
 }
@@ -143,18 +143,18 @@ auto succ::ThrusterController::update_and_write_commands(
     const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/) -> cif::return_type {
     if (this->mode == ThrusterMode::Can) {
         constexpr auto servo_enabled_index =
-            suc_util::get_index("servo/servo/enabled_raw", can_cmd_interface_names);
+            suc_util::get_index("servo/servo/enabled_raw", CAN_CMD_INTERFACE_NAMES);
         constexpr auto angle_index =
-            suc_util::get_index("servo/servo/angle_raw", can_cmd_interface_names);
+            suc_util::get_index("servo/servo/angle_raw", CAN_CMD_INTERFACE_NAMES);
         constexpr auto esc_enabled_index =
-            suc_util::get_index("esc/esc/enabled_raw", can_cmd_interface_names);
+            suc_util::get_index("esc/esc/enabled_raw", CAN_CMD_INTERFACE_NAMES);
         constexpr auto thrust_index =
-            suc_util::get_index("esc/esc/thrust_raw", can_cmd_interface_names);
+            suc_util::get_index("esc/esc/thrust_raw", CAN_CMD_INTERFACE_NAMES);
 
         constexpr auto servo_current_index =
-            suc_util::get_index("servo/servo/servo_current_raw", can_state_interface_names);
+            suc_util::get_index("servo/servo/servo_current_raw", CAN_STATE_INTERFACE_NAMES);
         constexpr auto rpm_index =
-            suc_util::get_index("esc/esc/rpm_raw", can_state_interface_names);
+            suc_util::get_index("esc/esc/rpm_raw", CAN_STATE_INTERFACE_NAMES);
 
         this->can_interface_helper_->set_cmd_value(servo_enabled_index, this->servo_enabled);
         this->can_interface_helper_->set_cmd_value(angle_index, this->angle);
@@ -165,13 +165,13 @@ auto succ::ThrusterController::update_and_write_commands(
         this->can_interface_helper_->get_state_value(rpm_index, this->rpm);
     } else {
         constexpr auto servo_enabled_index = suc_util::get_index(
-            "servo_direct/servo_direct/enabled_raw", direct_cmd_interface_names);
+            "servo_direct/servo_direct/enabled_raw", DIRECT_CMD_INTERFACE_NAMES);
         constexpr auto angle_index =
-            suc_util::get_index("servo_direct/servo_direct/angle_raw", direct_cmd_interface_names);
+            suc_util::get_index("servo_direct/servo_direct/angle_raw", DIRECT_CMD_INTERFACE_NAMES);
         constexpr auto esc_enabled_index =
-            suc_util::get_index("esc_direct/esc_direct/enabled_raw", direct_cmd_interface_names);
+            suc_util::get_index("esc_direct/esc_direct/enabled_raw", DIRECT_CMD_INTERFACE_NAMES);
         constexpr auto thrust_index =
-            suc_util::get_index("esc_direct/esc_direct/thrust_raw", direct_cmd_interface_names);
+            suc_util::get_index("esc_direct/esc_direct/thrust_raw", DIRECT_CMD_INTERFACE_NAMES);
 
         this->direct_interface_helper_->set_cmd_value(servo_enabled_index, this->servo_enabled);
         this->direct_interface_helper_->set_cmd_value(angle_index, this->angle);


### PR DESCRIPTION
#45 の続き。

とりあえず`**_interface_names`というメンバ変数を用意するところまで行いました。