### PR TITLE
chore(vscode): add `tasks.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 
 # VSCode
 .vscode/*
+!.vscode/tasks.json

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "colcon: build",
+      "type": "shell",
+      "command": "colcon",
+      "args": [
+        "build",
+        "--symlink-install",
+      ]
+    },
+    {
+      "label": "ros2: launch",
+      "type": "shell",
+      "dependsOn": [
+        "colcon: build",
+      ],
+      "command": [
+        "source",
+        "${workspaceFolder}/install/setup.bash",
+        "&&",
+        "ros2",
+        "launch",
+        "sinsei_umiusi_control",
+        "launch.xml"
+      ],
+    }
+  ]
+}


### PR DESCRIPTION
resolves #73 

コマンドパレットからbuildやlaunchができるよう`tasks.json`を追加しました。

`sinsei_umiusi_control`という名前がハードコードされているのがちょっと嫌ですが、`.env`ファイルから読み込む方法がなさそうだったので一旦諦めます。