### PR TITLE
:recycle: Refactor

### DIFF
--- a/include/sinsei_umiusi_control/cmd/led_tape.hpp
+++ b/include/sinsei_umiusi_control/cmd/led_tape.hpp
@@ -1,6 +1,7 @@
-#include <cstdint>
 #ifndef SINSEI_UMIUSI_CONTROL_LED_TAPE_HPP
 #define SINSEI_UMIUSI_CONTROL_LED_TAPE_HPP
+
+#include <cstdint>
 
 namespace sinsei_umiusi_control::cmd::led_tape {
 

--- a/include/sinsei_umiusi_control/cmd/thruster.hpp
+++ b/include/sinsei_umiusi_control/cmd/thruster.hpp
@@ -1,6 +1,7 @@
-#include <cstdint>
 #ifndef SINSEI_UMIUSI_CONTROL_CMD_THRUSTER_HPP
 #define SINSEI_UMIUSI_CONTROL_CMD_THRUSTER_HPP
+
+#include <cstdint>
 
 namespace sinsei_umiusi_control::cmd::thruster {
 

--- a/include/sinsei_umiusi_control/controller/app_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/app_controller.hpp
@@ -10,22 +10,20 @@
 #include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/imu.hpp"
 
-namespace suc = sinsei_umiusi_control;
-
 namespace sinsei_umiusi_control::controller {
 
 class AppController : public controller_interface::ChainableControllerInterface {
   private:
     // Command interfaces (in)
-    suc::cmd::app::Orientation target_orientation;
-    suc::cmd::app::Velocity target_velocity;
+    sinsei_umiusi_control::cmd::app::Orientation target_orientation;
+    sinsei_umiusi_control::cmd::app::Velocity target_velocity;
 
     // State interfaces (out)
-    suc::state::imu::Orientation imu_orientation;
-    suc::state::imu::Velocity imu_velocity;
+    sinsei_umiusi_control::state::imu::Orientation imu_orientation;
+    sinsei_umiusi_control::state::imu::Velocity imu_velocity;
 
-    std::array<suc::cmd::thruster::Angle, 4> thruster_angles;
-    std::array<suc::cmd::thruster::Thrust, 4> thruster_thrusts;
+    std::array<sinsei_umiusi_control::cmd::thruster::Angle, 4> thruster_angles;
+    std::array<sinsei_umiusi_control::cmd::thruster::Thrust, 4> thruster_thrusts;
 
     auto compute_outputs() -> void;
 

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -10,8 +10,6 @@
 #include "sinsei_umiusi_control/interface_access_helper.hpp"
 #include "sinsei_umiusi_control/state/thruster.hpp"
 
-namespace suc = sinsei_umiusi_control;
-
 namespace sinsei_umiusi_control::controller {
 
 enum class ThrusterMode {
@@ -22,14 +20,14 @@ enum class ThrusterMode {
 class ThrusterController : public controller_interface::ChainableControllerInterface {
   private:
     // Command interfaces (in)
-    suc::cmd::thruster::ServoEnabled servo_enabled;
-    suc::cmd::thruster::EscEnabled esc_enabled;
-    suc::cmd::thruster::Angle angle;
-    suc::cmd::thruster::Thrust thrust;
+    sinsei_umiusi_control::cmd::thruster::ServoEnabled servo_enabled;
+    sinsei_umiusi_control::cmd::thruster::EscEnabled esc_enabled;
+    sinsei_umiusi_control::cmd::thruster::Angle angle;
+    sinsei_umiusi_control::cmd::thruster::Thrust thrust;
 
     // State interfaces (out)
-    suc::state::thruster::ServoCurrent servo_current;
-    suc::state::thruster::Rpm rpm;
+    sinsei_umiusi_control::state::thruster::ServoCurrent servo_current;
+    sinsei_umiusi_control::state::thruster::Rpm rpm;
 
     // 正式なinterface名は前に`thruster(_direct)(1-4)/`がつくが、リストを静的にするため特別に省略している
     static constexpr size_t CAN_CMD_SIZE = 4;

--- a/include/sinsei_umiusi_control/hardware/can.hpp
+++ b/include/sinsei_umiusi_control/hardware/can.hpp
@@ -2,12 +2,7 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_CAN_HPP
 
 #include <hardware_interface/system_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
-
-#include "sinsei_umiusi_control/cmd/led_tape.hpp"
-#include "sinsei_umiusi_control/cmd/thruster.hpp"
-#include "sinsei_umiusi_control/state/main_power.hpp"
 
 namespace sinsei_umiusi_control::hardware {
 

--- a/include/sinsei_umiusi_control/hardware/headlights.hpp
+++ b/include/sinsei_umiusi_control/hardware/headlights.hpp
@@ -2,11 +2,9 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_HEADLIGHTS_HPP
 
 #include <hardware_interface/system_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
 
 #include "sinsei_umiusi_control/hardware_model/headlights_model.hpp"
-#include "sinsei_umiusi_control/util/pigpio.hpp"
 
 namespace sinsei_umiusi_control::hardware {
 

--- a/include/sinsei_umiusi_control/hardware/imu.hpp
+++ b/include/sinsei_umiusi_control/hardware/imu.hpp
@@ -2,11 +2,9 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_IMU_HPP
 
 #include <hardware_interface/sensor_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
 
 #include "sinsei_umiusi_control/hardware_model/imu_model.hpp"
-#include "sinsei_umiusi_control/util/pigpio.hpp"
 
 namespace sinsei_umiusi_control::hardware {
 

--- a/include/sinsei_umiusi_control/hardware/indicator_led.hpp
+++ b/include/sinsei_umiusi_control/hardware/indicator_led.hpp
@@ -2,11 +2,9 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_INDICATOR_LED_HPP
 
 #include <hardware_interface/system_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
 
 #include "sinsei_umiusi_control/hardware_model/indicator_led_model.hpp"
-#include "sinsei_umiusi_control/util/pigpio.hpp"
 
 namespace sinsei_umiusi_control::hardware {
 

--- a/include/sinsei_umiusi_control/hardware/thruster_direct/esc_direct.hpp
+++ b/include/sinsei_umiusi_control/hardware/thruster_direct/esc_direct.hpp
@@ -2,10 +2,7 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_THRUSTER_DIRECT_ESC_DIRECT_HPP
 
 #include <hardware_interface/system_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
-
-#include "sinsei_umiusi_control/cmd/thruster.hpp"
 
 namespace sinsei_umiusi_control::hardware::thruster_direct {
 

--- a/include/sinsei_umiusi_control/hardware/thruster_direct/servo_direct.hpp
+++ b/include/sinsei_umiusi_control/hardware/thruster_direct/servo_direct.hpp
@@ -2,10 +2,7 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_THRUSTER_DIRECT_SERVO_DIRECT_HPP
 
 #include <hardware_interface/system_interface.hpp>
-#include <memory>
 #include <rclcpp/macros.hpp>
-
-#include "sinsei_umiusi_control/cmd/thruster.hpp"
 
 namespace sinsei_umiusi_control::hardware::thruster_direct {
 

--- a/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
@@ -1,6 +1,7 @@
 #ifndef SINSEI_UMIUSI_CONTROL_hardware_model_HEADLIGHTS_MODEL_HPP
 #define SINSEI_UMIUSI_CONTROL_hardware_model_HEADLIGHTS_MODEL_HPP
 
+#include <cstdint>
 #include <memory>
 #include <rcpputils/tl_expected/expected.hpp>
 #include <string>

--- a/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
@@ -2,6 +2,8 @@
 #define SINSEI_UMIUSI_CONTROL_hardware_model_HEADLIGHTS_MODEL_HPP
 
 #include <memory>
+#include <rcpputils/tl_expected/expected.hpp>
+#include <string>
 
 #include "sinsei_umiusi_control/cmd/headlights.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
@@ -12,15 +14,16 @@ namespace sinsei_umiusi_control::hardware_model {
 
 class HeadlightsModel {
   private:
-    std::unique_ptr<util::GpioInterface> high_beam_gpio;
-    std::unique_ptr<util::GpioInterface> low_beam_gpio;
-    std::unique_ptr<util::GpioInterface> ir_gpio;
+    std::unique_ptr<util::GpioInterface> gpio;
+    uint8_t high_beam_pin;
+    uint8_t low_beam_pin;
+    uint8_t ir_pin;
 
   public:
     HeadlightsModel(
-        std::unique_ptr<util::GpioInterface> high_beam_gpio,
-        std::unique_ptr<util::GpioInterface> low_beam_gpio,
-        std::unique_ptr<util::GpioInterface> ir_gpio);
+        std::unique_ptr<util::GpioInterface> gpio, uint8_t high_beam_pin, uint8_t low_beam_pin,
+        uint8_t ir_pin);
+    auto on_init() -> tl::expected<void, std::string>;
     auto on_read() -> void;
     auto on_write(
         sinsei_umiusi_control::cmd::headlights::HighBeamEnabled & high_beam_enabled,

--- a/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
@@ -9,8 +9,6 @@
 #include "sinsei_umiusi_control/cmd/headlights.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
 
-namespace suc = sinsei_umiusi_control;
-
 namespace sinsei_umiusi_control::hardware_model {
 
 class HeadlightsModel {

--- a/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/headlights_model.hpp
@@ -25,11 +25,12 @@ class HeadlightsModel {
         std::unique_ptr<util::GpioInterface> gpio, uint8_t high_beam_pin, uint8_t low_beam_pin,
         uint8_t ir_pin);
     auto on_init() -> tl::expected<void, std::string>;
-    auto on_read() -> void;
+    auto on_read() -> tl::expected<void, std::string>;
     auto on_write(
         sinsei_umiusi_control::cmd::headlights::HighBeamEnabled & high_beam_enabled,
         sinsei_umiusi_control::cmd::headlights::LowBeamEnabled & low_beam_enabled,
-        sinsei_umiusi_control::cmd::headlights::IrEnabled & ir_enabled) -> void;
+        sinsei_umiusi_control::cmd::headlights::IrEnabled & ir_enabled)
+        -> tl::expected<void, std::string>;
 };
 
 }  // namespace sinsei_umiusi_control::hardware_model

--- a/include/sinsei_umiusi_control/hardware_model/imu_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/imu_model.hpp
@@ -9,8 +9,6 @@
 #include "sinsei_umiusi_control/state/imu.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
 
-namespace suc = sinsei_umiusi_control;
-
 namespace sinsei_umiusi_control::hardware_model {
 
 class ImuModel {
@@ -43,8 +41,9 @@ class ImuModel {
     auto begin() -> tl::expected<void, std::string>;
     auto on_read() -> tl::expected<
                        std::tuple<
-                           suc::state::imu::Orientation, suc::state::imu::Velocity,
-                           suc::state::imu::Temperature>,
+                           sinsei_umiusi_control::state::imu::Orientation,
+                           sinsei_umiusi_control::state::imu::Velocity,
+                           sinsei_umiusi_control::state::imu::Temperature>,
                        std::string>;
 };
 

--- a/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
@@ -9,8 +9,6 @@
 #include "sinsei_umiusi_control/cmd/indicator_led.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
 
-namespace suc = sinsei_umiusi_control;
-
 namespace sinsei_umiusi_control::hardware_model {
 
 class IndicatorLedModel {

--- a/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
@@ -1,6 +1,7 @@
 #ifndef SINSEI_UMIUSI_CONTROL_hardware_model_INDICATOR_LED_MODEL_HPP
 #define SINSEI_UMIUSI_CONTROL_hardware_model_INDICATOR_LED_MODEL_HPP
 
+#include <cstdint>
 #include <memory>
 #include <rcpputils/tl_expected/expected.hpp>
 #include <string>

--- a/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
@@ -21,8 +21,9 @@ class IndicatorLedModel {
   public:
     IndicatorLedModel(std::unique_ptr<util::GpioInterface> gpio, uint8_t led_pin);
     auto on_init() -> tl::expected<void, std::string>;
-    auto on_read() -> void;
-    auto on_write(sinsei_umiusi_control::cmd::indicator_led::Enabled & enabled) -> void;
+    auto on_read() -> tl::expected<void, std::string>;
+    auto on_write(sinsei_umiusi_control::cmd::indicator_led::Enabled & enabled)
+        -> tl::expected<void, std::string>;
 };
 
 }  // namespace sinsei_umiusi_control::hardware_model

--- a/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/indicator_led_model.hpp
@@ -2,6 +2,8 @@
 #define SINSEI_UMIUSI_CONTROL_hardware_model_INDICATOR_LED_MODEL_HPP
 
 #include <memory>
+#include <rcpputils/tl_expected/expected.hpp>
+#include <string>
 
 #include "sinsei_umiusi_control/cmd/indicator_led.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
@@ -13,9 +15,11 @@ namespace sinsei_umiusi_control::hardware_model {
 class IndicatorLedModel {
   private:
     std::unique_ptr<util::GpioInterface> gpio;
+    uint8_t led_pin;
 
   public:
-    IndicatorLedModel(std::unique_ptr<util::GpioInterface> gpio);
+    IndicatorLedModel(std::unique_ptr<util::GpioInterface> gpio, uint8_t led_pin);
+    auto on_init() -> tl::expected<void, std::string>;
     auto on_read() -> void;
     auto on_write(sinsei_umiusi_control::cmd::indicator_led::Enabled & enabled) -> void;
 };

--- a/include/sinsei_umiusi_control/interface_access_helper.hpp
+++ b/include/sinsei_umiusi_control/interface_access_helper.hpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+
 namespace sinsei_umiusi_control {
 
 template <std::size_t CMD_SIZE, std::size_t STATE_SIZE>

--- a/include/sinsei_umiusi_control/state/imu.hpp
+++ b/include/sinsei_umiusi_control/state/imu.hpp
@@ -1,6 +1,7 @@
-#include <cstdint>
 #ifndef SINSEI_UMIUSI_CONTROL_STATE_IMU_HPP
 #define SINSEI_UMIUSI_CONTROL_STATE_IMU_HPP
+
+#include <cstdint>
 
 namespace sinsei_umiusi_control::state::imu {
 

--- a/include/sinsei_umiusi_control/state/main_power.hpp
+++ b/include/sinsei_umiusi_control/state/main_power.hpp
@@ -1,6 +1,7 @@
-#include <cstdint>
 #ifndef SINSEI_UMIUSI_CONTROL_STATE_MAIN_POWER_HPP
 #define SINSEI_UMIUSI_CONTROL_STATE_MAIN_POWER_HPP
+
+#include <cstdint>
 
 namespace sinsei_umiusi_control::state::main_power {
 

--- a/include/sinsei_umiusi_control/util/constexpr.hpp
+++ b/include/sinsei_umiusi_control/util/constexpr.hpp
@@ -2,6 +2,7 @@
 #define SINSEI_UMIUSI_CONTROL_UTIL_CONSTEXPR_HPP
 
 #include <cstddef>
+
 namespace sinsei_umiusi_control::util {
 
 // ref: https://stackoverflow.com/questions/51114180/constexpr-find-for-array-using-c17

--- a/include/sinsei_umiusi_control/util/gpio_interface.hpp
+++ b/include/sinsei_umiusi_control/util/gpio_interface.hpp
@@ -23,12 +23,6 @@ enum class GpioError {
     UnknownError,
 };
 
-// TODO: GpioErrorに置き換えたら削除する
-enum class GpioResult {
-    Success,
-    Error,
-};
-
 class GpioInterface {
   public:
     GpioInterface() = default;
@@ -36,9 +30,8 @@ class GpioInterface {
 
     virtual auto set_mode_output(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> = 0;
     virtual auto set_mode_input(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> = 0;
-    // TODO: GpioResultをtl::expected<void, GpioError>に置き換える
-    virtual auto write_digital(uint8_t pin, bool enabled) -> GpioResult = 0;
-    virtual auto write_pwm() -> GpioResult = 0;
+    virtual auto write_digital(uint8_t pin, bool enabled) -> tl::expected<void, GpioError> = 0;
+    virtual auto write_pwm() -> tl::expected<void, GpioError> = 0;
 
     virtual auto i2c_open(int address) -> tl::expected<void, GpioError> = 0;
     virtual auto i2c_close() -> tl::expected<void, GpioError> = 0;

--- a/include/sinsei_umiusi_control/util/gpio_interface.hpp
+++ b/include/sinsei_umiusi_control/util/gpio_interface.hpp
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 #include <rcpputils/tl_expected/expected.hpp>
-#include <string>
 
 namespace sinsei_umiusi_control::util {
 
@@ -35,8 +34,10 @@ class GpioInterface {
     GpioInterface() = default;
     virtual ~GpioInterface() = default;
 
+    virtual auto set_mode_output(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> = 0;
+    virtual auto set_mode_input(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> = 0;
     // TODO: GpioResultをtl::expected<void, GpioError>に置き換える
-    virtual auto write_digital(bool enabled) -> GpioResult = 0;
+    virtual auto write_digital(uint8_t pin, bool enabled) -> GpioResult = 0;
     virtual auto write_pwm() -> GpioResult = 0;
 
     virtual auto i2c_open(int address) -> tl::expected<void, GpioError> = 0;

--- a/include/sinsei_umiusi_control/util/pigpio.hpp
+++ b/include/sinsei_umiusi_control/util/pigpio.hpp
@@ -1,7 +1,8 @@
 #ifndef SINSEI_UMIUSI_CONTROL_UTIL_PIGPIO_HPP
 #define SINSEI_UMIUSI_CONTROL_UTIL_PIGPIO_HPP
 
-#include <pigpiod_if2.h>
+#include <rcpputils/tl_expected/expected.hpp>
+#include <vector>
 
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
 
@@ -11,18 +12,19 @@ class Pigpio : public GpioInterface {
   private:
     int pi;
 
-    int pin_number;
-
     static constexpr int I2C_BUS = 1;
     int i2c_handle = -1;
     int i2c_address;
 
   public:
-    Pigpio(int pin_number);
+    // 失敗しうるので注意
+    Pigpio();
     ~Pigpio();
 
+    auto set_mode_output(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> override;
+    auto set_mode_input(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> override;
     // TODO: GpioResultをtl::expected<void, GpioError>に置き換える
-    auto write_digital(bool enabled) -> GpioResult override;
+    auto write_digital(uint8_t pin, bool enabled) -> GpioResult override;
     auto write_pwm() -> GpioResult override;
 
     auto i2c_open(int address) -> tl::expected<void, GpioError> override;

--- a/include/sinsei_umiusi_control/util/pigpio.hpp
+++ b/include/sinsei_umiusi_control/util/pigpio.hpp
@@ -23,9 +23,8 @@ class Pigpio : public GpioInterface {
 
     auto set_mode_output(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> override;
     auto set_mode_input(std::vector<uint8_t> pins) -> tl::expected<void, GpioError> override;
-    // TODO: GpioResultをtl::expected<void, GpioError>に置き換える
-    auto write_digital(uint8_t pin, bool enabled) -> GpioResult override;
-    auto write_pwm() -> GpioResult override;
+    auto write_digital(uint8_t pin, bool enabled) -> tl::expected<void, GpioError> override;
+    auto write_pwm() -> tl::expected<void, GpioError> override;
 
     auto i2c_open(int address) -> tl::expected<void, GpioError> override;
     auto i2c_close() -> tl::expected<void, GpioError> override;

--- a/src/sinsei_umiusi_control/hardware/headlights.cpp
+++ b/src/sinsei_umiusi_control/hardware/headlights.cpp
@@ -1,5 +1,9 @@
 #include "sinsei_umiusi_control/hardware/headlights.hpp"
 
+#include <memory>
+
+#include "sinsei_umiusi_control/util/pigpio.hpp"
+
 namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;
@@ -7,12 +11,21 @@ namespace rlc = rclcpp_lifecycle;
 auto suchw::Headlights::on_init(const hif::HardwareInfo & info) -> hif::CallbackReturn {
     this->hif::SystemInterface::on_init(info);
 
+    auto gpio = std::make_unique<sinsei_umiusi_control::util::Pigpio>();
+    auto high_beam_pin = std::make_unique<sinsei_umiusi_control::util::Pigpio>();
+    auto low_beam_pin = std::make_unique<sinsei_umiusi_control::util::Pigpio>();
+    auto ir_pin = std::make_unique<sinsei_umiusi_control::util::Pigpio>();
+
     // FIXME: ピン番号はパラメーターなどで設定できるようにする
     this->model.emplace(
-        std::make_unique<sinsei_umiusi_control::util::Pigpio>(5),  // High Beam
-        std::make_unique<sinsei_umiusi_control::util::Pigpio>(6),  // Low Beam
-        std::make_unique<sinsei_umiusi_control::util::Pigpio>(25)  // IR
+        std::move(gpio),
+        5,  // High beam
+        6,  // Low beam
+        25  // IR
     );
+
+    // TODO: エラー処理を追加
+    this->model->on_init();
 
     return hif::CallbackReturn::SUCCESS;
 }

--- a/src/sinsei_umiusi_control/hardware/imu.cpp
+++ b/src/sinsei_umiusi_control/hardware/imu.cpp
@@ -7,8 +7,8 @@ namespace rlc = rclcpp_lifecycle;
 auto suchw::Imu::on_init(const hif::HardwareInfo & info) -> hif::CallbackReturn {
     this->hif::SensorInterface::on_init(info);
 
-    // FIXME: Pigpioクラスの初期化にはピン番号が必要なため、適当な値を使用
-    this->model.emplace(std::make_unique<sinsei_umiusi_control::util::Pigpio>(999));
+    this->model.emplace(std::make_unique<sinsei_umiusi_control::util::Pigpio>());
+
     auto res = this->model->begin();
     if (!res) {
         RCLCPP_ERROR(this->get_logger(), "Failed to initialize IMU: %s", res.error().c_str());

--- a/src/sinsei_umiusi_control/hardware/imu.cpp
+++ b/src/sinsei_umiusi_control/hardware/imu.cpp
@@ -1,5 +1,7 @@
 #include "sinsei_umiusi_control/hardware/imu.hpp"
 
+#include "sinsei_umiusi_control/util/pigpio.hpp"
+
 namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;

--- a/src/sinsei_umiusi_control/hardware/indicator_led.cpp
+++ b/src/sinsei_umiusi_control/hardware/indicator_led.cpp
@@ -1,5 +1,7 @@
 #include "sinsei_umiusi_control/hardware/indicator_led.hpp"
 
+#include "sinsei_umiusi_control/util/pigpio.hpp"
+
 namespace suchw = sinsei_umiusi_control::hardware;
 namespace hif = hardware_interface;
 namespace rlc = rclcpp_lifecycle;

--- a/src/sinsei_umiusi_control/hardware/indicator_led.cpp
+++ b/src/sinsei_umiusi_control/hardware/indicator_led.cpp
@@ -7,8 +7,13 @@ namespace rlc = rclcpp_lifecycle;
 auto suchw::IndicatorLed::on_init(const hif::HardwareInfo & info) -> hif::CallbackReturn {
     this->hif::SystemInterface::on_init(info);
 
+    auto led_pin = std::make_unique<sinsei_umiusi_control::util::Pigpio>();
+
     // FIXME: ピン番号はパラメーターなどで設定できるようにする
-    this->model.emplace(std::make_unique<sinsei_umiusi_control::util::Pigpio>(24));
+    this->model.emplace(std::move(led_pin), 24);
+
+    // TODO: エラー処理を追加
+    this->model->on_init();
 
     return hif::CallbackReturn::SUCCESS;
 }

--- a/src/sinsei_umiusi_control/hardware_model/headlights_model.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/headlights_model.cpp
@@ -4,12 +4,25 @@ namespace suc = sinsei_umiusi_control;
 namespace suchm = suc::hardware_model;
 
 suchm::HeadlightsModel::HeadlightsModel(
-    std::unique_ptr<suc::util::GpioInterface> high_beam_gpio,
-    std::unique_ptr<suc::util::GpioInterface> low_beam_gpio,
-    std::unique_ptr<suc::util::GpioInterface> ir_gpio)
-: high_beam_gpio(std::move(high_beam_gpio)),
-  low_beam_gpio(std::move(low_beam_gpio)),
-  ir_gpio(std::move(ir_gpio)) {}
+    std::unique_ptr<suc::util::GpioInterface> gpio,
+    uint8_t high_beam_pin,  // NOLINT(bugprone-easily-swappable-parameters) TODO: いずれ修正したい
+    uint8_t low_beam_pin, uint8_t ir_pin)
+: gpio(std::move(gpio)), high_beam_pin(high_beam_pin), low_beam_pin(low_beam_pin), ir_pin(ir_pin) {}
+
+auto suchm::HeadlightsModel::on_init() -> tl::expected<void, std::string> {
+    return this->gpio->set_mode_output({this->high_beam_pin, this->low_beam_pin, this->ir_pin})
+        .map_error([](const auto & e) {
+            switch (e) {
+                case util::GpioError::BadGpio:
+                    return std::string("Bad GPIO pin specified for Headlights");
+                case util::GpioError::NotPermitted:
+                    return std::string("Not permitted to set GPIO pin mode for Headlights");
+                default:
+                    return std::string(
+                        "Unknown error occurred while setting GPIO pin mode for Headlights");
+            }
+        });
+}
 
 auto suchm::HeadlightsModel::on_read() -> void {}
 
@@ -17,7 +30,7 @@ auto suchm::HeadlightsModel::on_write(
     sinsei_umiusi_control::cmd::headlights::HighBeamEnabled & high_beam_enabled,
     sinsei_umiusi_control::cmd::headlights::LowBeamEnabled & low_beam_enabled,
     sinsei_umiusi_control::cmd::headlights::IrEnabled & ir_enabled) -> void {
-    this->high_beam_gpio->write_digital(high_beam_enabled.value);
-    this->low_beam_gpio->write_digital(low_beam_enabled.value);
-    this->ir_gpio->write_digital(ir_enabled.value);
+    this->gpio->write_digital(this->high_beam_pin, high_beam_enabled.value);
+    this->gpio->write_digital(this->low_beam_pin, low_beam_enabled.value);
+    this->gpio->write_digital(this->ir_pin, ir_enabled.value);
 }

--- a/src/sinsei_umiusi_control/hardware_model/indicator_led_model.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/indicator_led_model.cpp
@@ -1,14 +1,33 @@
 #include "sinsei_umiusi_control/hardware_model/indicator_led_model.hpp"
 
+#include <rcpputils/tl_expected/expected.hpp>
+
+#include "sinsei_umiusi_control/util/gpio_interface.hpp"
+
 namespace suc = sinsei_umiusi_control;
 namespace suchm = suc::hardware_model;
 
-suchm::IndicatorLedModel::IndicatorLedModel(std::unique_ptr<suc::util::GpioInterface> gpio)
-: gpio(std::move(gpio)) {}
+suchm::IndicatorLedModel::IndicatorLedModel(
+    std::unique_ptr<suc::util::GpioInterface> gpio, uint8_t led_pin)
+: gpio(std::move(gpio)), led_pin(led_pin) {}
+
+auto suchm::IndicatorLedModel::on_init() -> tl::expected<void, std::string> {
+    return this->gpio->set_mode_output({this->led_pin}).map_error([](const auto & e) {
+        switch (e) {
+            case util::GpioError::BadGpio:
+                return std::string("Bad GPIO pin specified for Indicator LED");
+            case util::GpioError::NotPermitted:
+                return std::string("Not permitted to set GPIO pin mode for Indicator LED");
+            default:
+                return std::string(
+                    "Unknown error occurred while setting GPIO pin mode for Indicator LED");
+        }
+    });
+}
 
 auto suchm::IndicatorLedModel::on_read() -> void {}
 
 auto suchm::IndicatorLedModel::on_write(
     sinsei_umiusi_control::cmd::indicator_led::Enabled & enabled) -> void {
-    this->gpio->write_digital(enabled.value);
+    this->gpio->write_digital(this->led_pin, enabled.value);
 }

--- a/src/sinsei_umiusi_control/util/pigpio.cpp
+++ b/src/sinsei_umiusi_control/util/pigpio.cpp
@@ -45,18 +45,26 @@ auto suc_util::Pigpio::set_mode_input(std::vector<uint8_t> pins) -> tl::expected
     return {};
 }
 
-auto suc_util::Pigpio::write_digital(uint8_t pin, bool enabled) -> GpioResult {
-    // TODO: 返り値を`tl::expected<void, GpioError>`に変更する
+auto suc_util::Pigpio::write_digital(uint8_t pin, bool enabled) -> tl::expected<void, GpioError> {
     auto res = gpio_write(pi, pin, enabled ? 1 : 0);
-    if (res == PI_BAD_GPIO || res == PI_BAD_LEVEL || res == PI_NOT_PERMITTED) {
-        return GpioResult::Error;
+    if (res == 0) {
+        return {};
     }
-    return GpioResult::Success;
+    switch (res) {
+        case PI_BAD_GPIO:
+            return tl::unexpected(GpioError::BadGpio);
+        case PI_BAD_LEVEL:
+            return tl::unexpected(GpioError::BadLevel);
+        case PI_NOT_PERMITTED:
+            return tl::unexpected(GpioError::NotPermitted);
+        default:
+            return tl::unexpected(GpioError::UnknownError);
+    }
 }
 
-auto suc_util::Pigpio::write_pwm() -> GpioResult {
+auto suc_util::Pigpio::write_pwm() -> tl::expected<void, GpioError> {
     // TODO: PWMの処理を実装する
-    return GpioResult::Error;
+    return tl::unexpected(GpioError::UnknownError);
 }
 
 auto suc_util::Pigpio::i2c_open(int address) -> tl::expected<void, GpioError> {

--- a/test/cpp/hardware_model.cpp
+++ b/test/cpp/hardware_model.cpp
@@ -33,12 +33,8 @@ class Gpio : public sinsei_umiusi_control::util::GpioInterface {
     MOCK_METHOD1(
         set_mode_output, tl::expected<void, sucutil::GpioError>(std::vector<uint8_t> pins));
     MOCK_METHOD1(set_mode_input, tl::expected<void, sucutil::GpioError>(std::vector<uint8_t> pins));
-    MOCK_METHOD2(
-        write_digital,
-        sucutil::GpioResult(
-            uint8_t pin,
-            bool enabled));  // TODO: GpioResultをtl::expected<void, GpioError>に置き換える
-    MOCK_METHOD0(write_pwm, sucutil::GpioResult());  // TODO: 未実装
+    MOCK_METHOD2(write_digital, tl::expected<void, sucutil::GpioError>(uint8_t pin, bool enabled));
+    MOCK_METHOD0(write_pwm, tl::expected<void, sucutil::GpioError>());  // TODO: 未実装
     MOCK_METHOD1(i2c_open, tl::expected<void, sucutil::GpioError>(int address));
     MOCK_METHOD0(i2c_close, tl::expected<void, sucutil::GpioError>());
     MOCK_METHOD1(i2c_write_byte, tl::expected<void, sucutil::GpioError>(uint8_t value));

--- a/test/cpp/hardware_model.cpp
+++ b/test/cpp/hardware_model.cpp
@@ -12,7 +12,6 @@
 #include "sinsei_umiusi_control/hardware_model/headlights_model.hpp"
 #include "sinsei_umiusi_control/hardware_model/imu_model.hpp"
 #include "sinsei_umiusi_control/hardware_model/indicator_led_model.hpp"
-#include "sinsei_umiusi_control/state/imu.hpp"
 #include "sinsei_umiusi_control/util/gpio_interface.hpp"
 
 namespace suchm = sinsei_umiusi_control::hardware_model;


### PR DESCRIPTION
コードを整えたり、簡単なTODOをつぶしたりしました。

横断的にやっちゃったのでリストアップしておきます:

- `GpioInterface`の仕様を変更しました。
  - 初期化にピン番号がいらなくなりました。
  - かわりに`set_mode_(output|input)`関数を呼ぶことでピンモードを設定するようにしました。
  - `write_digital`にてピン番号を引数に入れるようにしました。
  - `write_digital`と`write_pwm`の返り値を`GpioResult`から`tl::expected<void, GpioError>`に変更しました。
- `headlights_model`と`indicator_led_model`にて、エラー時にログを出力するよう処理を追加しました。
- いらない`include`宣言を消したり、ヘッダファイルになくて良いものをソースファイルに移動したりしました。