### PR TITLE
refactor!(namespace): :recycle: 名前空間を整理

### DIFF
--- a/config/controllers.yml
+++ b/config/controllers.yml
@@ -1,37 +1,38 @@
-controller_manager:
-  ros__parameters:
-    update_rate: 100 # Hz
+/**:
+  controller_manager:
+    ros__parameters:
+      update_rate: 100 # Hz
 
-gate_controller:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/GateController
-    update_rate: 50 # Hz
+  gate_controller:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/GateController
+      update_rate: 50 # Hz
 
-app_controller:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/AppController
-    update_rate: 50 # Hz
+  app_controller:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/AppController
+      update_rate: 50 # Hz
 
-thruster_controller1:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/ThrusterController
-    update_rate: 50 # Hz
-    id: 1
+  thruster_controller1:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/ThrusterController
+      update_rate: 50 # Hz
+      id: 1
 
-thruster_controller2:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/ThrusterController
-    update_rate: 50 # Hz
-    id: 2
+  thruster_controller2:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/ThrusterController
+      update_rate: 50 # Hz
+      id: 2
 
-thruster_controller3:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/ThrusterController
-    update_rate: 50 # Hz
-    id: 3
+  thruster_controller3:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/ThrusterController
+      update_rate: 50 # Hz
+      id: 3
 
-thruster_controller4:
-  ros__parameters:
-    type: sinsei_umiusi_control/controller/ThrusterController
-    update_rate: 50 # Hz
-    id: 4
+  thruster_controller4:
+    ros__parameters:
+      type: sinsei_umiusi_control/controller/ThrusterController
+      update_rate: 50 # Hz
+      id: 4

--- a/launch/launch.xml
+++ b/launch/launch.xml
@@ -7,6 +7,8 @@
   <!-- Launch Arguments -->
   <arg name="thruster_mode" default="can" />
 
+  <arg name="namespace" default="" />
+
   <arg name="robot_description"
     default="$(command 'xacro $(find-pkg-share $(var pkg_name))/urdf/sinsei_umiusi_control.urdf.xacro thruster_mode:=\&apos;\&quot;$(var thruster_mode)\&quot;\&apos;')" />
 
@@ -17,16 +19,20 @@
   <!-- Launch nodes -->
   <node
     pkg="controller_manager"
-    exec="ros2_control_node" output="both">
+    exec="ros2_control_node" namespace="/$(var namespace)" output="both">
     <param from="$(var robot_controllers_path)" />
     <param name="thruster_mode" value="$(var thruster_mode)" />
   </node>
 
-  <node pkg="controller_manager"
+  <node
+    pkg="controller_manager"
     exec="spawner"
-    args="thruster_controller1 thruster_controller2 thruster_controller3 thruster_controller4 app_controller gate_controller --param-file $(var robot_controllers_path)" />
+    args="thruster_controller1 thruster_controller2 thruster_controller3 thruster_controller4 app_controller gate_controller --param-file $(var robot_controllers_path)"
+    namespace="/$(var namespace)" />
 
-  <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
+  <node pkg="robot_state_publisher"
+    exec="robot_state_publisher" namespace="/$(var namespace)"
+    output="both">
     <param name="robot_description" value="$(var robot_description)" />
   </node>
 

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -40,21 +40,23 @@ auto succ::GateController::on_init() -> cif::CallbackReturn {
 
 auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
     -> cif::CallbackReturn {
+    const auto cmd_prefix = std::string("cmd/");
+    const auto state_prefix = std::string("state/");
     this->indicator_led_enabled_subscriber =
         this->get_node()->create_subscription<std_msgs::msg::Bool>(
-            "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
+            cmd_prefix + "indicator_led_enabled", rclcpp::SystemDefaultsQoS(),
             [this](const std_msgs::msg::Bool::SharedPtr input) {
                 this->indicator_led_enabled_ref.value = input->data;
             });
     this->main_power_enabled_subscriber =
         this->get_node()->create_subscription<std_msgs::msg::Bool>(
-            "main_power_enabled", rclcpp::SystemDefaultsQoS(),
+            cmd_prefix + "main_power_enabled", rclcpp::SystemDefaultsQoS(),
             [this](const std_msgs::msg::Bool::SharedPtr input) {
                 this->main_power_enabled_ref.value = input->data;
             });
     this->led_tape_color_subscriber =
         this->get_node()->create_subscription<std_msgs::msg::ColorRGBA>(
-            "led_tape_color", rclcpp::SystemDefaultsQoS(),
+            cmd_prefix + "led_tape_color", rclcpp::SystemDefaultsQoS(),
             [this](const std_msgs::msg::ColorRGBA::SharedPtr input) {
                 // alphaは無視
                 this->led_tape_color_ref.red = static_cast<uint8_t>(input->r);
@@ -62,33 +64,33 @@ auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
                 this->led_tape_color_ref.blue = static_cast<uint8_t>(input->b);
             });
     this->high_beam_enabled_subscriber = this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "high_beam_enabled", rclcpp::SystemDefaultsQoS(),
+        cmd_prefix + "high_beam_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
             this->high_beam_enabled_ref.value = input->data;
         });
     this->low_beam_enabled_subscriber = this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "low_beam_enabled", rclcpp::SystemDefaultsQoS(),
+        cmd_prefix + "low_beam_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
             this->low_beam_enabled_ref.value = input->data;
         });
     this->ir_enabled_subscriber = this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "ir_enabled", rclcpp::SystemDefaultsQoS(),
+        cmd_prefix + "ir_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
             this->ir_enabled_ref.value = input->data;
         });
     this->servo_enabled_subscriber = this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "servo_enabled", rclcpp::SystemDefaultsQoS(),
+        cmd_prefix + "servo_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
             this->servo_enabled_ref.value = input->data;
         });
     this->esc_enabled_subscriber = this->get_node()->create_subscription<std_msgs::msg::Bool>(
-        "esc_enabled", rclcpp::SystemDefaultsQoS(),
+        cmd_prefix + "esc_enabled", rclcpp::SystemDefaultsQoS(),
         [this](const std_msgs::msg::Bool::SharedPtr input) {
             this->esc_enabled_ref.value = input->data;
         });
     this->target_orientation_subscriber =
         this->get_node()->create_subscription<geometry_msgs::msg::Vector3>(
-            "target_orientation", rclcpp::SystemDefaultsQoS(),
+            cmd_prefix + "target_orientation", rclcpp::SystemDefaultsQoS(),
             [this](const geometry_msgs::msg::Vector3::SharedPtr input) {
                 this->target_orientation_ref.x = input->x;
                 this->target_orientation_ref.y = input->y;
@@ -96,7 +98,7 @@ auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
             });
     this->target_velocity_subscriber =
         this->get_node()->create_subscription<geometry_msgs::msg::Vector3>(
-            "target_velocity", rclcpp::SystemDefaultsQoS(),
+            cmd_prefix + "target_velocity", rclcpp::SystemDefaultsQoS(),
             [this](const geometry_msgs::msg::Vector3::SharedPtr input) {
                 this->target_velocity_ref.x = input->x;
                 this->target_velocity_ref.y = input->y;
@@ -104,27 +106,28 @@ auto succ::GateController::on_configure(const rlc::State & /*pervious_state*/)
             });
 
     this->battery_current_publisher = this->get_node()->create_publisher<std_msgs::msg::Float64>(
-        "battery_current", rclcpp::SystemDefaultsQoS());
+        state_prefix + "battery_current", rclcpp::SystemDefaultsQoS());
     this->battery_voltage_publisher = this->get_node()->create_publisher<std_msgs::msg::Float64>(
-        "battery_voltage", rclcpp::SystemDefaultsQoS());
+        state_prefix + "battery_voltage", rclcpp::SystemDefaultsQoS());
     this->main_temperature_publisher = this->get_node()->create_publisher<std_msgs::msg::Int8>(
-        "main_temperature", rclcpp::SystemDefaultsQoS());
+        state_prefix + "main_temperature", rclcpp::SystemDefaultsQoS());
     this->water_leaked_publisher = this->get_node()->create_publisher<std_msgs::msg::Bool>(
-        "water_leaked", rclcpp::SystemDefaultsQoS());
+        state_prefix + "water_leaked", rclcpp::SystemDefaultsQoS());
     for (size_t i = 0; i < 4; ++i) {
         this->servo_current_publisher[i] =
             this->get_node()->create_publisher<std_msgs::msg::Float64>(
-                "servo_current_" + std::to_string(i + 1), rclcpp::SystemDefaultsQoS());
+                state_prefix + "servo_current_" + std::to_string(i + 1),
+                rclcpp::SystemDefaultsQoS());
         this->rpm_publisher[i] = this->get_node()->create_publisher<std_msgs::msg::Float64>(
-            "rpm_" + std::to_string(i + 1), rclcpp::SystemDefaultsQoS());
+            state_prefix + "rpm_" + std::to_string(i + 1), rclcpp::SystemDefaultsQoS());
     }
     this->imu_orientation_publisher =
         this->get_node()->create_publisher<geometry_msgs::msg::Vector3>(
-            "imu_orientation", rclcpp::SystemDefaultsQoS());
+            state_prefix + "imu_orientation", rclcpp::SystemDefaultsQoS());
     this->imu_velocity_publisher = this->get_node()->create_publisher<geometry_msgs::msg::Vector3>(
-        "imu_velocity", rclcpp::SystemDefaultsQoS());
+        state_prefix + "imu_velocity", rclcpp::SystemDefaultsQoS());
     this->imu_temperature_publisher = this->get_node()->create_publisher<std_msgs::msg::Float64>(
-        "imu_temperature", rclcpp::SystemDefaultsQoS());
+        state_prefix + "imu_temperature", rclcpp::SystemDefaultsQoS());
 
     return cif::CallbackReturn::SUCCESS;
 }


### PR DESCRIPTION
- launch argumentから全体を名前空間でくるめるようにした
- Command Interfaceにつながっているトピックを`cmd`
  State Interfaceにつながっているトピックを`state`
  名前空間でくるんだ