### PR TITLE
fix: `launch.xml`以外から`thruster_mode`のデフォルト値を削除

### DIFF
--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -63,7 +63,7 @@ auto succ::ThrusterController::on_init() -> cif::CallbackReturn {
     this->id = this->get_node()->get_parameter("id").as_int();
     RCLCPP_INFO(this->get_node()->get_logger(), "Thruster ID: %d", this->id);
 
-    this->get_node()->declare_parameter("thruster_mode", "can");
+    this->get_node()->declare_parameter("thruster_mode", "unknown");
     std::string mode_str = this->get_node()->get_parameter("thruster_mode").as_string();
     auto mode_res = util::get_mode_from_str(mode_str);
     if (!mode_res) {

--- a/urdf/sinsei_umiusi_control.urdf.xacro
+++ b/urdf/sinsei_umiusi_control.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
-  <xacro:arg name="thruster_mode" default="'can'" />
+  <xacro:arg name="thruster_mode" default="unknown" />
 
   <xacro:include filename="sinsei_umiusi_control/can.urdf.xacro" />
   <xacro:include filename="sinsei_umiusi_control/thruster_direct.urdf.xacro" />

--- a/urdf/sinsei_umiusi_control.urdf.xacro
+++ b/urdf/sinsei_umiusi_control.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="UMIUSI">
-  <xacro:arg name="thruster_mode" default="unknown" />
+  <xacro:arg name="thruster_mode" default="'unknown'" />
 
   <xacro:include filename="sinsei_umiusi_control/can.urdf.xacro" />
   <xacro:include filename="sinsei_umiusi_control/thruster_direct.urdf.xacro" />


### PR DESCRIPTION
close #92

これによって、`thruster_mode`が`can`か`direct`かどうかを決定する要素が

- コマンドラインで渡す引数
- `launch.xml`に書かれたデフォルト値（`can`）

のみになりました。

コマンドラインで`thruster_mode`を`can`や`direct`以外に指定するとセグフォしますが、以前からの挙動みたいです。