### PR TITLE
refactor(linux_can): :recycle: refactor `LinuxCan`

### DIFF
--- a/include/sinsei_umiusi_control/util/can_interface.hpp
+++ b/include/sinsei_umiusi_control/util/can_interface.hpp
@@ -20,9 +20,9 @@ class CanInterface {
 
     virtual auto init(const std::string ifname) -> tl::expected<void, std::string> = 0;
     virtual auto close() -> tl::expected<void, std::string> = 0;
-    virtual auto send_stdframe(uint32_t id, const uint8_t * data, size_t length)
+    virtual auto send_frame_std(uint32_t id, const uint8_t * data, size_t length)
         -> tl::expected<void, std::string> = 0;
-    virtual auto send_extframe(uint32_t id, const uint8_t * data, size_t length)
+    virtual auto send_frame_ext(uint32_t id, const uint8_t * data, size_t length)
         -> tl::expected<void, std::string> = 0;
     virtual auto recv_frame() -> tl::expected<CanFrame, std::string> = 0;
 };

--- a/include/sinsei_umiusi_control/util/linux_can.hpp
+++ b/include/sinsei_umiusi_control/util/linux_can.hpp
@@ -19,9 +19,9 @@ class LinuxCan : public CanInterface {
 
     auto init(const std::string ifname) -> tl::expected<void, std::string> override;
     auto close() -> tl::expected<void, std::string> override;
-    auto send_stdframe(uint32_t id, const uint8_t * data, size_t length)
+    auto send_frame_std(uint32_t id, const uint8_t * data, size_t length)
         -> tl::expected<void, std::string> override;
-    auto send_extframe(uint32_t id, const uint8_t * data, size_t length)
+    auto send_frame_ext(uint32_t id, const uint8_t * data, size_t length)
         -> tl::expected<void, std::string> override;
     auto recv_frame() -> tl::expected<CanFrame, std::string> override;
 };

--- a/src/sinsei_umiusi_control/hardware_model/can/vesc_model.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/can/vesc_model.cpp
@@ -23,7 +23,7 @@ auto suchm::can::VescModel::send_command_packet(
     VescSimpleCommandID command_id,
     const std::array<uint8_t, 4> & data) -> tl::expected<void, std::string> {
     auto can_id = (static_cast<uint32_t>(command_id) & 0xFF) << 8 | (this->id & 0xFF);
-    return this->can->send_extframe(can_id, data.data(), data.size());
+    return this->can->send_frame_ext(can_id, data.data(), data.size());
 }
 
 auto suchm::can::VescModel::recv_status_frame(VescStatusCommandID expected_cmd_id)

--- a/src/sinsei_umiusi_control/util/linux_can.cpp
+++ b/src/sinsei_umiusi_control/util/linux_can.cpp
@@ -7,8 +7,10 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstring>
+#include <rcpputils/tl_expected/expected.hpp>
 
 namespace suc_util = sinsei_umiusi_control::util;
 
@@ -16,46 +18,56 @@ suc_util::LinuxCan::LinuxCan() : sock(-1) {}
 
 auto suc_util::LinuxCan::close() -> tl::expected<void, std::string> {
     if (this->sock < 0) {
-        return tl::unexpected<std::string>("CAN socket is not initialized");
+        return tl::make_unexpected("CAN socket is not initialized");
     }
     auto res = ::close(this->sock);
     if (res < 0) {
-        return tl::unexpected<std::string>(
-            "Failed to close CAN socket: " + std::string(strerror(errno)));
+        return tl::make_unexpected("Failed to close CAN socket: " + std::string(strerror(errno)));
     }
+    this->sock = -1;
     return {};
 }
 
 auto suc_util::LinuxCan::init(const std::string ifname) -> tl::expected<void, std::string> {
-    this->sock = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    // Create a socket
+    this->sock = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
     if (this->sock < 0) {
-        return tl::unexpected<std::string>(
-            "Failed to create CAN socket: " + std::string(strerror(errno)));
+        return tl::make_unexpected("Failed to create CAN socket: " + std::string(strerror(errno)));
     }
 
+    // Interface request (name -> if_index mapping)
     struct ifreq ifr {};
     std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
-
-    if (ioctl(this->sock, SIOCGIFINDEX, &ifr) < 0) {
-        ::close(this->sock);
-        this->sock = -1;
-        return tl::unexpected<std::string>(
+    auto res = ::ioctl(this->sock, SIOCGIFINDEX, &ifr);
+    if (res < 0) {
+        auto res = this->close();
+        if (!res) {
+            return tl::make_unexpected(
+                "Failed to close CAN socket after ioctl failure: " + res.error());
+        }
+        return tl::make_unexpected(
             "Failed to get interface index: " + std::string(strerror(errno)));
     }
 
+    // Set up the socket address structure
     sockaddr_can addr{};
     addr.can_family = AF_CAN;
     addr.can_ifindex = ifr.ifr_ifindex;
 
-    int loopback = 0;
-    setsockopt(this->sock, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback));
-    setsockopt(this->sock, SOL_CAN_RAW, CAN_RAW_FILTER, nullptr, 0);
+    // Disable local loopback mode and ID filters
+    const bool loopback = false;
+    ::setsockopt(this->sock, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback));
+    ::setsockopt(this->sock, SOL_CAN_RAW, CAN_RAW_FILTER, nullptr, 0);
 
-    if (bind(this->sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0) {
-        ::close(this->sock);
-        this->sock = -1;
-        return tl::unexpected<std::string>(
-            "Failed to bind CAN socket: " + std::string(strerror(errno)));
+    // Bind the socket to the CAN interface
+    res = ::bind(this->sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+    if (res < 0) {
+        auto res = this->close();
+        if (!res) {
+            return tl::make_unexpected(
+                "Failed to close CAN socket after bind failure: " + res.error());
+        }
+        return tl::make_unexpected("Failed to bind CAN socket: " + std::string(strerror(errno)));
     }
 
     return {};
@@ -65,75 +77,97 @@ auto suc_util::LinuxCan::send_frame(
     uint32_t id, const uint8_t * data, size_t length,
     bool is_extended) -> tl::expected<void, std::string> {
     if (this->sock < 0) {
-        return tl::unexpected<std::string>("CAN socket is not initialized");
+        return tl::make_unexpected("CAN socket is not initialized");
     }
 
     if (length > CAN_MAX_DLEN) {
-        return tl::unexpected<std::string>("DLC exceeds maximum allowed CAN data length");
+        return tl::make_unexpected("DLC exceeds maximum allowed CAN data length");
     }
 
+    // Prepare a CAN frame to send
     can_frame frame{};
-    frame.can_id = is_extended ? (id | CAN_EFF_FLAG) : (id & CAN_SFF_MASK);
-    frame.can_dlc = static_cast<__u8>(length);
-    std::memcpy(frame.data, data, length);
+    if (is_extended) {
+        frame.can_id = (id & CAN_EFF_MASK) | CAN_EFF_FLAG;  // Extended frame ID
+    } else {
+        frame.can_id = id & CAN_SFF_MASK;  // Standard frame ID
+    }
+    frame.can_dlc = static_cast<uint8_t>(length);  // always safe (bc. length <= CAN_MAX_DLEN = 8)
+    const auto data_begin = data;
+    const auto data_end = data + length;
+    std::copy(data_begin, data_end, frame.data);
 
-    ssize_t nbytes = write(this->sock, &frame, sizeof(can_frame));
-    if (nbytes < 0) {
-        return tl::unexpected<std::string>(
-            "Failed to write CAN frame: " + std::string(strerror(errno)));
+    // Send the CAN frame
+    const auto bytes_to_write = sizeof(frame);
+    const auto bytes_written = ::write(this->sock, &frame, bytes_to_write);
+    if (bytes_written < 0) {
+        return tl::make_unexpected("Failed to write CAN frame: " + std::string(strerror(errno)));
     }
 
-    if (static_cast<size_t>(nbytes) < sizeof(can_frame)) {
-        return tl::unexpected<std::string>("Partial CAN frame written");
+    if (static_cast<size_t>(bytes_written) != bytes_to_write) {
+        return tl::make_unexpected(
+            "Incomplete CAN frame written: expected " + std::to_string(bytes_to_write) +
+            " bytes, got " + std::to_string(bytes_written) + " bytes");
     }
 
     return {};
 }
 
-auto suc_util::LinuxCan::send_stdframe(uint32_t id, const uint8_t * data, size_t length)
+auto suc_util::LinuxCan::send_frame_std(uint32_t id, const uint8_t * data, size_t length)
     -> tl::expected<void, std::string> {
-    return send_frame(id, data, length, false);
+    return this->send_frame(id, data, length, false);
 }
 
-auto suc_util::LinuxCan::send_extframe(uint32_t id, const uint8_t * data, size_t length)
+auto suc_util::LinuxCan::send_frame_ext(uint32_t id, const uint8_t * data, size_t length)
     -> tl::expected<void, std::string> {
-    return send_frame(id, data, length, true);
+    return this->send_frame(id, data, length, true);
 }
 
 auto suc_util::LinuxCan::recv_frame() -> tl::expected<CanFrame, std::string> {
     if (this->sock < 0) {
-        return tl::unexpected<std::string>("CAN socket is not initialized");
+        return tl::make_unexpected("CAN socket is not initialized");
     }
 
-    fd_set rdfs;
-    FD_ZERO(&rdfs);
-    FD_SET(this->sock, &rdfs);
+    fd_set read_fds;
+    FD_ZERO(&read_fds);             // Clear the set
+    FD_SET(this->sock, &read_fds);  // Add the socket to the set
 
-    int timeout_ms = 1000;
-    struct timeval timeout;
-    timeout.tv_sec = timeout_ms / 1000;
-    timeout.tv_usec = (static_cast<__suseconds_t>(timeout_ms % 1000)) * 1000;
+    // Set a timeout for select (1 sec)
+    constexpr int TIMEOUT_MS = 1000;
+    struct timeval timeout = {
+        TIMEOUT_MS / 1000,                                 // seconds
+        (static_cast<int64_t>(TIMEOUT_MS % 1000)) * 1000,  // microseconds
+    };
 
-    int ret = select(this->sock + 1, &rdfs, nullptr, nullptr, &timeout);
-    if (ret < 0) {
-        return tl::unexpected<std::string>("select() failed: " + std::string(strerror(errno)));
-    } else if (ret == 0) {
-        return tl::unexpected<std::string>("select() timeout");
+    // Wait for data to be available on the socket
+    const auto nfds = this->sock + 1;  // highest file descriptor + 1
+    auto res = ::select(nfds, &read_fds, nullptr, nullptr, &timeout);
+    if (res < 0) {
+        return tl::make_unexpected("select() failed: " + std::string(strerror(errno)));
+    } else if (res == 0) {
+        return tl::make_unexpected("No data available on CAN socket within timeout period");
     }
 
+    // Read the CAN frame from the socket
     struct can_frame frame {};
-    ssize_t nbytes = read(this->sock, &frame, sizeof(frame));
-    if (nbytes < 0) {
-        return tl::unexpected<std::string>("read() failed: " + std::string(strerror(errno)));
+    const auto bytes_to_read = sizeof(frame);
+    const auto bytes_read = ::read(this->sock, &frame, bytes_to_read);
+    if (bytes_read < 0) {
+        return tl::make_unexpected("read() failed: " + std::string(strerror(errno)));
     }
-    if (static_cast<size_t>(nbytes) != sizeof(struct can_frame)) {
-        return tl::unexpected<std::string>("Incomplete CAN frame read");
+    if (static_cast<size_t>(bytes_read) != bytes_to_read) {
+        return tl::make_unexpected(
+            "Incomplete CAN frame read: expected " + std::to_string(bytes_to_read) +
+            " bytes, got " + std::to_string(bytes_read) + " bytes");
     }
 
-    CanFrame result;
+    // Prepare the CanFrame result
+    CanFrame result{};
     result.id = frame.can_id;
     result.dlc = frame.can_dlc;
-    std::memcpy(result.data.data(), frame.data, CAN_MAX_DLEN);
+    const auto data_length = std::min<uint8_t>(frame.can_dlc, CAN_MAX_DLEN);
+    const auto data_begin = frame.data;
+    const auto data_end = frame.data + data_length;
+    std::copy(data_begin, data_end, result.data.begin());
 
     return result;
 }


### PR DESCRIPTION
ロジックに影響しうる変更点:

- `LinuxCan::close()`内で`this->socket`を`-1`で初期化するようにした。
- `::close(); this->socket = -1;`を`this->close();`で置き換えた。
- ローカル変数`loopback`の型を`int`から`bool`に変更した。
- 配列の`std::memcpy`を`std::copy`に置き換えた。
- 拡張CANの`id`を`CAN_EFF_MASK`でマスクするように変更した。