### PR TITLE
feat: PWMの実装

### DIFF
--- a/include/sinsei_umiusi_control/hardware_model/impl/pigpio.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/impl/pigpio.hpp
@@ -32,7 +32,7 @@ class Pigpio : public interface::Gpio {
     auto set_mode_output(const std::vector<Pin> & pins) -> tl::expected<void, Error> override;
     auto set_mode_input(const std::vector<Pin> & pins) -> tl::expected<void, Error> override;
     auto write_digital(const Pin & pin, bool && enabled) -> tl::expected<void, Error> override;
-    auto write_pwm() -> tl::expected<void, Error> override;
+    auto write_pwm(const Pin & pin, const int && pulsewidth) -> tl::expected<void, Error> override;
 
     auto i2c_open(const Addr & address) -> tl::expected<void, Error> override;
     auto i2c_close() -> tl::expected<void, Error> override;

--- a/include/sinsei_umiusi_control/hardware_model/interface/gpio.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/interface/gpio.hpp
@@ -15,6 +15,7 @@ enum class GpioError {
     BadFlags,
     BadHandle,
     BadParameter,
+    BadPulsewidth,
     NoHandle,
     I2cNotOpen,
     I2cBadBus,
@@ -39,6 +40,8 @@ inline auto gpio_error_to_string(const GpioError & error) -> std::string {
             return "Bad handle specified";
         case GpioError::BadParameter:
             return "Bad parameter specified";
+        case GpioError::BadPulsewidth:
+            return "Bad pulsewidth specified";
         case GpioError::NoHandle:
             return "No handle available";
         case GpioError::I2cNotOpen:
@@ -70,7 +73,8 @@ class Gpio {
     virtual auto set_mode_output(const std::vector<Pin> & pins) -> tl::expected<void, Error> = 0;
     virtual auto set_mode_input(const std::vector<Pin> & pins) -> tl::expected<void, Error> = 0;
     virtual auto write_digital(const Pin & pin, bool && enabled) -> tl::expected<void, Error> = 0;
-    virtual auto write_pwm() -> tl::expected<void, Error> = 0;
+    virtual auto write_pwm(const Pin & pin, const int && pulsewidth)
+        -> tl::expected<void, Error> = 0;
 
     virtual auto i2c_open(const Addr & address) -> tl::expected<void, Error> = 0;
     virtual auto i2c_close() -> tl::expected<void, Error> = 0;

--- a/src/sinsei_umiusi_control/hardware_model/impl/pigpio.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/impl/pigpio.cpp
@@ -66,9 +66,22 @@ auto suchm::impl::Pigpio::write_digital(const Pin & pin, bool && enabled)
     }
 }
 
-auto suchm::impl::Pigpio::write_pwm() -> tl::expected<void, Error> {
-    // TODO: PWMの処理を実装する
-    return tl::unexpected(Error::UnknownError);
+auto suchm::impl::Pigpio::write_pwm(const Pin & pin, const int && pulsewidth)
+    -> tl::expected<void, Error> {
+    const auto res = ::set_servo_pulsewidth(pi, pin, pulsewidth);
+    if (res == 0) {
+        return {};
+    }
+    switch (res) {
+        case PI_BAD_GPIO:
+            return tl::unexpected(Error::BadGpio);
+        case PI_BAD_PULSEWIDTH:
+            return tl::unexpected(Error::BadPulsewidth);
+        case PI_NOT_PERMITTED:
+            return tl::unexpected(Error::NotPermitted);
+        default:
+            return tl::unexpected(Error::UnknownError);
+    }
 }
 
 auto suchm::impl::Pigpio::i2c_open(const Addr & address) -> tl::expected<void, Error> {

--- a/test/cpp/mock/gpio.hpp
+++ b/test/cpp/mock/gpio.hpp
@@ -20,8 +20,9 @@ class Gpio : public hardware_model::interface::Gpio {
     MOCK_METHOD2(
         write_digital, tl::expected<void, hardware_model::interface::Gpio::Error>(
                            const hardware_model::interface::Gpio::Pin & pin, bool && enabled));
-    MOCK_METHOD0(
-        write_pwm, tl::expected<void, hardware_model::interface::Gpio::Error>());  // TODO: 未実装
+    MOCK_METHOD2(
+        write_pwm, tl::expected<void, hardware_model::interface::Gpio::Error>(
+                       const hardware_model::interface::Gpio::Pin & pin, const int && pulsewidth));
     MOCK_METHOD1(
         i2c_open, tl::expected<void, hardware_model::interface::Gpio::Error>(
                       const hardware_model::interface::Gpio::Addr & address));

--- a/test/cpp/util.cpp
+++ b/test/cpp/util.cpp
@@ -21,6 +21,7 @@ TEST(GpioInterfaceTest, gpio_error_to_string) {
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::BadFlags), unknown_msg);
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::BadHandle), unknown_msg);
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::BadParameter), unknown_msg);
+    EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::BadPulsewidth), unknown_msg);
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::NoHandle), unknown_msg);
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::I2cNotOpen), unknown_msg);
     EXPECT_NE(suchm::interface::gpio_error_to_string(GpioError::I2cBadBus), unknown_msg);


### PR DESCRIPTION
VESCが使えない時用。

最終的には`esc_direct`や`servo_direct`の中身も書かないといけない