### PR TITLE
:sparkles: スラスターを直接コントロール可能にした

### DIFF
--- a/include/sinsei_umiusi_control/cmd/thruster.hpp
+++ b/include/sinsei_umiusi_control/cmd/thruster.hpp
@@ -3,16 +3,16 @@
 
 namespace sinsei_umiusi_control::cmd::thruster {
 
-struct ServoEnabled {
-    bool value;
-};
 struct EscEnabled {
     bool value;
 };
-struct Angle {
-    double value;
+struct ServoEnabled {
+    bool value;
 };
 struct DutyCycle {
+    double value;
+};
+struct Angle {
     double value;
 };
 

--- a/include/sinsei_umiusi_control/controller/attitude_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/attitude_controller.hpp
@@ -19,11 +19,13 @@ namespace sinsei_umiusi_control::controller {
 class AttitudeController : public controller_interface::ChainableControllerInterface {
   public:
     struct Input {
-        struct Command {  // Command interfaces (in)
+        // Command interfaces (in)
+        struct Command {
             cmd::attitude::Orientation target_orientation;
             cmd::attitude::Velocity target_velocity;
         };
-        struct State {  // State interfaces (out)
+        // State interfaces (in)
+        struct State {
             state::imu::Quaternion imu_quaternion;
             state::imu::Velocity imu_velocity;
             std::array<state::thruster::Rpm, 4> thruster_rpms;
@@ -33,9 +35,10 @@ class AttitudeController : public controller_interface::ChainableControllerInter
     };
 
     struct Output {
-        struct Command {  // Command interfaces (out)
-            std::array<cmd::thruster::Angle, 4> thruster_angles;
+        // Command interfaces (out)
+        struct Command {
             std::array<cmd::thruster::DutyCycle, 4> thruster_duty_cycles;
+            std::array<cmd::thruster::Angle, 4> thruster_angles;
         };
         Command cmd;
     };

--- a/include/sinsei_umiusi_control/controller/gate_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/gate_controller.hpp
@@ -35,15 +35,18 @@ class GateController : public controller_interface::ControllerInterface {
         sinsei_umiusi_control::cmd::headlights::HighBeamEnabled high_beam_enabled_ref;
         sinsei_umiusi_control::cmd::headlights::LowBeamEnabled low_beam_enabled_ref;
         sinsei_umiusi_control::cmd::headlights::IrEnabled ir_enabled_ref;
+
+        // TODO: スラスタごとに分ける
         sinsei_umiusi_control::cmd::thruster::ServoEnabled servo_enabled_ref;
         sinsei_umiusi_control::cmd::thruster::EscEnabled esc_enabled_ref;
+
         sinsei_umiusi_control::cmd::led_tape::Color led_tape_color_ref;
         sinsei_umiusi_control::cmd::attitude::Orientation target_orientation_ref;
         sinsei_umiusi_control::cmd::attitude::Velocity target_velocity_ref;
     };
     Command cmd;
 
-    // State interfaces (out)
+    // State interfaces (in)
     struct State {
         sinsei_umiusi_control::state::main_power::BatteryCurrent battery_current;
         sinsei_umiusi_control::state::main_power::BatteryVoltage battery_voltage;
@@ -53,6 +56,10 @@ class GateController : public controller_interface::ControllerInterface {
         sinsei_umiusi_control::state::imu::Quaternion imu_quaternion;
         sinsei_umiusi_control::state::imu::Velocity imu_velocity;
         std::array<sinsei_umiusi_control::state::thruster::Rpm, 4> rpm;
+        std::array<sinsei_umiusi_control::state::thruster::EscEnabled, 4> esc_enabled;
+        std::array<sinsei_umiusi_control::state::thruster::ServoEnabled, 4> servo_enabled;
+        std::array<sinsei_umiusi_control::state::thruster::DutyCycle, 4> thruster_duty_cycles;
+        std::array<sinsei_umiusi_control::state::thruster::Angle, 4> thruster_angles;
         std::array<sinsei_umiusi_control::state::esc::WaterLeaked, 4> esc_water_leaked;
     };
     State state;
@@ -82,6 +89,10 @@ class GateController : public controller_interface::ControllerInterface {
         rclcpp::Publisher<geometry_msgs::msg::Quaternion>::SharedPtr imu_quaternion_publisher;
         rclcpp::Publisher<geometry_msgs::msg::Vector3>::SharedPtr imu_velocity_publisher;
         std::array<rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr, 4> rpm_publisher;
+        std::array<rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr, 4> esc_enabled_publisher;
+        std::array<rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr, 4> servo_enabled_publisher;
+        std::array<rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr, 4> duty_cycles_publisher;
+        std::array<rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr, 4> angle_publisher;
         std::array<rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr, 4> esc_water_leaked_publisher;
     };
     Publishers pub;

--- a/include/sinsei_umiusi_control/controller/thruster_controller.hpp
+++ b/include/sinsei_umiusi_control/controller/thruster_controller.hpp
@@ -3,12 +3,15 @@
 
 #include <controller_interface/chainable_controller_interface.hpp>
 #include <hardware_interface/hardware_interface/handle.hpp>
+#include <rclcpp/subscription.hpp>
 #include <vector>
 
 #include "sinsei_umiusi_control/cmd/thruster.hpp"
 #include "sinsei_umiusi_control/state/thruster.hpp"
 #include "sinsei_umiusi_control/util/interface_accessor.hpp"
 #include "sinsei_umiusi_control/util/thruster_mode.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float64.hpp"
 
 namespace sinsei_umiusi_control::controller {
 
@@ -17,27 +20,43 @@ class ThrusterController : public controller_interface::ChainableControllerInter
     struct Input {
         // Command interfaces (in)
         struct Command {
-            cmd::thruster::ServoEnabled servo_enabled;
             cmd::thruster::EscEnabled esc_enabled;
-            cmd::thruster::Angle angle;
+            cmd::thruster::ServoEnabled servo_enabled;
             cmd::thruster::DutyCycle duty_cycle;
+            cmd::thruster::Angle angle;
         };
         // State interfaces (in)
         struct State {
             state::thruster::Rpm rpm;
         };
+        // Subscribers for command inputs
+        struct Subscriber {
+            rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr esc_enabled;
+            rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr servo_enabled;
+            rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr duty_cycle;
+            rclcpp::Subscription<std_msgs::msg::Float64>::SharedPtr angle;
+        };
         Command cmd;
         State state;
+        Subscriber sub;
     };
     struct Output {
         // Command interfaces (out)
         struct Command {
-            cmd::thruster::ServoEnabled servo_enabled;
             cmd::thruster::EscEnabled esc_enabled;
-            cmd::thruster::Angle angle;
+            cmd::thruster::ServoEnabled servo_enabled;
             cmd::thruster::DutyCycle duty_cycle;
+            cmd::thruster::Angle angle;
+        };
+        // State interfaces (out)
+        struct State {
+            state::thruster::EscEnabled esc_enabled;
+            state::thruster::ServoEnabled servo_enabled;
+            state::thruster::DutyCycle duty_cycle;
+            state::thruster::Angle angle;
         };
         Command cmd;
+        State state;
     };
 
   private:

--- a/include/sinsei_umiusi_control/state/thruster.hpp
+++ b/include/sinsei_umiusi_control/state/thruster.hpp
@@ -6,6 +6,18 @@ namespace sinsei_umiusi_control::state::thruster {
 struct Rpm {
     double value;
 };
+struct EscEnabled {
+    bool value;
+};
+struct ServoEnabled {
+    bool value;
+};
+struct DutyCycle {
+    double value;
+};
+struct Angle {
+    double value;
+};
 
 }  // namespace sinsei_umiusi_control::state::thruster
 

--- a/src/sinsei_umiusi_control/controller/attitude_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/attitude_controller.cpp
@@ -92,10 +92,10 @@ auto AttitudeController::on_configure(const rclcpp_lifecycle::State & /*previous
     for (size_t i = 0; i < 4; ++i) {
         const auto prefix = "thruster_controller" + std::string(THRUSTER_SUFFIX[i]) + "/";
         this->command_interface_data.emplace_back(
-            prefix + "angle", util::to_interface_data_ptr(this->output.cmd.thruster_angles[i]));
-        this->command_interface_data.emplace_back(
             prefix + "duty_cycle",
             util::to_interface_data_ptr(this->output.cmd.thruster_duty_cycles[i]));
+        this->command_interface_data.emplace_back(
+            prefix + "angle", util::to_interface_data_ptr(this->output.cmd.thruster_angles[i]));
     }
 
     if (this->thruster_mode == util::ThrusterMode::Can) {

--- a/src/sinsei_umiusi_control/controller/gate_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/gate_controller.cpp
@@ -206,8 +206,7 @@ auto succ::GateController::on_configure(const rlc::State & /*previous_state*/)
             "attitude_controller/imu/velocity.z",
             to_interface_data_ptr(this->state.imu_velocity.z));
         for (size_t i = 0; i < 4; ++i) {
-            const auto prefix =
-                "thruster_controller" + std::string(THRUSTER_SUFFIX[i]) + "/thruster/";
+            const auto prefix = "thruster_controller" + std::string(THRUSTER_SUFFIX[i]) + "/";
 
             this->state_interface_data.emplace_back(
                 prefix + "esc_enabled", to_interface_data_ptr(this->state.esc_enabled[i].value));

--- a/src/sinsei_umiusi_control/controller/thruster_controller.cpp
+++ b/src/sinsei_umiusi_control/controller/thruster_controller.cpp
@@ -174,16 +174,16 @@ auto ThrusterController::on_export_state_interfaces()
             this->get_node()->get_name(), "thruster" + name.substr(OFFSET), data));
     }
     interfaces.emplace_back(hardware_interface::StateInterface(
-        this->get_node()->get_name(), "thruster/esc_enabled",
+        this->get_node()->get_name(), "esc_enabled",
         util::to_interface_data_ptr(this->output.state.esc_enabled)));
     interfaces.emplace_back(hardware_interface::StateInterface(
-        this->get_node()->get_name(), "thruster/servo_enabled",
+        this->get_node()->get_name(), "servo_enabled",
         util::to_interface_data_ptr(this->output.state.servo_enabled)));
     interfaces.emplace_back(hardware_interface::StateInterface(
-        this->get_node()->get_name(), "thruster/duty_cycle",
+        this->get_node()->get_name(), "duty_cycle",
         util::to_interface_data_ptr(this->output.state.duty_cycle)));
     interfaces.emplace_back(hardware_interface::StateInterface(
-        this->get_node()->get_name(), "thruster/angle",
+        this->get_node()->get_name(), "angle",
         util::to_interface_data_ptr(this->output.state.angle)));
 
     return interfaces;


### PR DESCRIPTION
- 追加したトピック
  - `/cmd/direct/thruster_controller_(lf|lb|rb|rf)/esc_enabled`
  - `/cmd/direct/thruster_controller_(lf|lb|rb|rf)/servo_enabled`
  - `/cmd/direct/thruster_controller_(lf|lb|rb|rf)/duty_cycle`
  - `/cmd/direct/thruster_controller_(lf|lb|rb|rf)/angle`
  - `/state/thruster_esc_enabled_(lf|lb|rb|rf)`
  - `/state/thruster_servo_enabled_(lf|lb|rb|rf)`
  - `/state/thruster_duty_cycle_(lf|lb|rb|rf)`
  - `/state/thruster_angle_(lf|lb|rb|rf)`
- 追加したState interface
  - `esc_enabled` (`thruster_controller_(lf|lb|rb|rf)` -> `gate_controller`)
  - `servo_enabled` (`thruster_controller_(lf|lb|rb|rf)` -> `gate_controller`)
  - `duty_cycle` (`thruster_controller_(lf|lb|rb|rf)` -> `gate_controller`)
  - `angle` (`thruster_controller_(lf|lb|rb|rf)` -> `gate_controller`)