### PR TITLE
fix(vesc): サーボの原点を90度に変更

### DIFF
--- a/src/sinsei_umiusi_control/hardware_model/can/vesc_model.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/can/vesc_model.cpp
@@ -51,12 +51,12 @@ auto can::VescModel::make_servo_frame(double && value) const
 
 auto can::VescModel::make_servo_angle_frame(double && deg) const
     -> tl::expected<interface::CanFrame, std::string> {
-    // 0.0 ~ 180.0度の角度を0.0 ~ 1.0に変換
-    if (deg < 0.0 || deg > 180.0) {
+    // -90.0 ~ 90.0度の角度を0.0 ~ 1.0に変換
+    if (deg < -90.0 || deg > 90.0) {
         return tl::make_unexpected(
-            "Servo angle must be between 0.0 and 180.0 degrees (deg: " + std::to_string(deg) + ")");
+            "Servo angle must be between -90.0 ~ 90.0 degrees (deg: " + std::to_string(deg) + ")");
     }
-    return this->make_servo_frame(std::move(deg) / 180.0);
+    return this->make_servo_frame((std::move(deg) + 90.0) / 180.0);
 }
 
 auto can::VescModel::id_matches(const interface::CanFrame & frame) const -> bool {

--- a/test/cpp/hardware_model/can/vesc.cpp
+++ b/test/cpp/hardware_model/can/vesc.cpp
@@ -66,7 +66,7 @@ TEST(VescModelTest, VescModelMakeServoAngleFrameValidTest) {
                    0xFF) << 8 |
                       DUMMY_ID);
     EXPECT_EQ(frame.len, 4);
-    EXPECT_EQ(sucutil::to_int32_be(frame.data), 5000);  // 90 / 180 * 10000
+    EXPECT_EQ(sucutil::to_int32_be(frame.data), 10000);  // (90 + 90) / 180 * 10000
 }
 
 TEST(VescModelTest, VescModelMakeServoAngleFrameInvalidTest) {


### PR DESCRIPTION
これにより、デフォルトでスラスタが横向きになった