### PR TITLE
:adhesive_bandage: VESC CANのランタイムエラーを修正

### DIFF
--- a/include/sinsei_umiusi_control/hardware_model/can/vesc_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/can/vesc_model.hpp
@@ -106,8 +106,7 @@ class VescModel {
 
     auto id_matches(const interface::CanFrame & frame) const -> bool;
 
-    static auto get_cmd_id(const interface::CanFrame & frame)
-        -> tl::expected<VescStatusCommandID, std::string>;
+    static auto get_cmd_id(const interface::CanFrame & frame) -> std::optional<VescStatusCommandID>;
 
   public:
     VescModel(Id id);

--- a/include/sinsei_umiusi_control/hardware_model/can/vesc_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/can/vesc_model.hpp
@@ -106,7 +106,8 @@ class VescModel {
 
     auto id_matches(const interface::CanFrame & frame) const -> bool;
 
-    static auto get_cmd_id(const interface::CanFrame & frame) -> std::optional<VescStatusCommandID>;
+    static auto get_cmd_id(const interface::CanFrame & frame)
+        -> tl::expected<VescStatusCommandID, std::string>;
 
   public:
     VescModel(Id id);

--- a/include/sinsei_umiusi_control/hardware_model/can_model.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/can_model.hpp
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <rcpputils/tl_expected/expected.hpp>
 #include <variant>
 
@@ -64,11 +65,11 @@ class CanModel {
     auto on_destroy() -> tl::expected<void, std::string>;
     auto on_read() const
         -> tl::expected<
-            std::variant<
+            std::optional<std::variant<
                 std::tuple<size_t, state::thruster::Rpm>,
                 std::tuple<size_t, state::esc::WaterLeaked>, state::main_power::BatteryCurrent,
                 state::main_power::BatteryVoltage, state::main_power::Temperature,
-                state::main_power::WaterLeaked>,
+                state::main_power::WaterLeaked>>,
             std::string>;
     auto on_write(
         cmd::main_power::Enabled && main_power_enabled,

--- a/include/sinsei_umiusi_control/hardware_model/impl/linux_can.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/impl/linux_can.hpp
@@ -3,6 +3,7 @@
 
 #include <linux/can.h>
 
+#include <limits>
 #include <optional>
 
 #include "sinsei_umiusi_control/hardware_model/interface/can.hpp"
@@ -18,6 +19,8 @@ class LinuxCan : public interface::Can {
     std::optional<FileDescriptor> sock_tx;
     std::optional<FileDescriptor> sock_rx;
 
+    CanFrame::Id id_last_sent = std::numeric_limits<CanFrame::Id>::max();
+
     auto send_linux_can_frame(can_frame && frame) -> tl::expected<void, std::string>;
     auto recv_linux_can_frame() -> tl::expected<can_frame, std::string>;
 
@@ -27,7 +30,7 @@ class LinuxCan : public interface::Can {
     auto init(const std::string ifname) -> tl::expected<void, std::string> override;
     auto close() -> tl::expected<void, std::string> override;
     auto send_frame(CanFrame && frame) -> tl::expected<void, std::string> override;
-    auto recv_frame() -> tl::expected<CanFrame, std::string> override;
+    auto recv_frame() -> tl::expected<std::optional<CanFrame>, std::string> override;
 };
 
 }  // namespace sinsei_umiusi_control::hardware_model::impl

--- a/include/sinsei_umiusi_control/hardware_model/interface/can.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/interface/can.hpp
@@ -2,6 +2,7 @@
 #define SINSEI_UMIUSI_CONTROL_HARDWARE_MODEL_INTERFACE_CAN_HPP
 
 #include <cstdint>
+#include <optional>
 #include <rcpputils/tl_expected/expected.hpp>
 #include <string>
 
@@ -29,7 +30,7 @@ class Can {
     virtual auto init(const std::string ifname) -> tl::expected<void, std::string> = 0;
     virtual auto close() -> tl::expected<void, std::string> = 0;
     virtual auto send_frame(CanFrame && frame) -> tl::expected<void, std::string> = 0;
-    virtual auto recv_frame() -> tl::expected<CanFrame, std::string> = 0;
+    virtual auto recv_frame() -> tl::expected<std::optional<CanFrame>, std::string> = 0;
 };
 
 }  // namespace sinsei_umiusi_control::hardware_model::interface

--- a/src/sinsei_umiusi_control/hardware/can.cpp
+++ b/src/sinsei_umiusi_control/hardware/can.cpp
@@ -90,8 +90,11 @@ auto suchw::Can::read(const rclcpp::Time & /*time*/, const rclcpp::Duration & /*
             res.error().c_str());
         return hif::return_type::OK;
     }
-
-    auto variant = res.value();
+    auto variant_opt = res.value();
+    if (!variant_opt) {
+        return hif::return_type::OK;
+    }
+    auto & variant = variant_opt.value();
 
     switch (variant.index()) {
         case 0: {  // Rpm

--- a/test/cpp/hardware_model/can.cpp
+++ b/test/cpp/hardware_model/can.cpp
@@ -63,7 +63,7 @@ TEST(CanModelTest, CanModelOnReadTest) {
 
     EXPECT_CALL(*can, recv_frame())
         .Times(1)
-        .WillOnce(Return(tl::expected<suchm::interface::CanFrame, std::string>{
+        .WillOnce(Return(tl::expected<std::optional<suchm::interface::CanFrame>, std::string>{
             suchm::interface::CanFrame{DUMMY_FRAME_ID_RECV, 8, DUMMY_FRAME_DATA_RECV, true}}));
 
     auto can_model = suchm::CanModel(can, VESC_IDS);

--- a/test/cpp/hardware_model/can/vesc.cpp
+++ b/test/cpp/hardware_model/can/vesc.cpp
@@ -117,8 +117,18 @@ TEST(VescModelTest, VescModelGetRpmInvalidFrameLengthTest) {
         {},
         true};
     auto result = vesc_model.get_rpm(frame);
-    ASSERT_TRUE(result);           // Should not fail,
-    ASSERT_FALSE(result.value());  // but return no value
+    ASSERT_FALSE(result);
+}
+
+TEST(VescModelTest, VescModelGetRpmInvalidCmdIdTest) {
+    auto vesc_model = suchm::can::VescModel{DUMMY_ID};
+    const auto frame = suchm::interface::CanFrame{
+        0xFF << 8 | DUMMY_ID,  // Invalid command ID
+        8,
+        {},
+        true};
+    auto result = vesc_model.get_rpm(frame);
+    ASSERT_FALSE(result);
 }
 
 TEST(VescModelTest, VescModelUnmatchedCommandIdTest) {
@@ -190,8 +200,18 @@ TEST(VescModelTest, VescModelGetWaterLeakedInvalidFrameLengthTest) {
         {},
         true};
     auto result = vesc_model.get_water_leaked(frame);
-    ASSERT_TRUE(result);           // Should not fail,
-    ASSERT_FALSE(result.value());  // but return no value
+    ASSERT_FALSE(result);
+}
+
+TEST(VescModelTest, VescModelGetWaterLeakedInvalidCmdIdTest) {
+    auto vesc_model = suchm::can::VescModel{DUMMY_ID};
+    const auto frame = suchm::interface::CanFrame{
+        0xFF << 8 | DUMMY_ID,  // Invalid command ID
+        8,
+        {},
+        true};
+    auto result = vesc_model.get_water_leaked(frame);
+    ASSERT_FALSE(result);
 }
 
 TEST(VescModelTest, VescModelGetWaterLeakedUnmatchedCommandIdTest) {

--- a/test/cpp/hardware_model/can/vesc.cpp
+++ b/test/cpp/hardware_model/can/vesc.cpp
@@ -117,18 +117,8 @@ TEST(VescModelTest, VescModelGetRpmInvalidFrameLengthTest) {
         {},
         true};
     auto result = vesc_model.get_rpm(frame);
-    ASSERT_FALSE(result);
-}
-
-TEST(VescModelTest, VescModelGetRpmInvalidCmdIdTest) {
-    auto vesc_model = suchm::can::VescModel{DUMMY_ID};
-    const auto frame = suchm::interface::CanFrame{
-        0xFF << 8 | DUMMY_ID,  // Invalid command ID
-        8,
-        {},
-        true};
-    auto result = vesc_model.get_rpm(frame);
-    ASSERT_FALSE(result);
+    ASSERT_TRUE(result);           // Should not fail,
+    ASSERT_FALSE(result.value());  // but return no value
 }
 
 TEST(VescModelTest, VescModelUnmatchedCommandIdTest) {
@@ -200,18 +190,8 @@ TEST(VescModelTest, VescModelGetWaterLeakedInvalidFrameLengthTest) {
         {},
         true};
     auto result = vesc_model.get_water_leaked(frame);
-    ASSERT_FALSE(result);
-}
-
-TEST(VescModelTest, VescModelGetWaterLeakedInvalidCmdIdTest) {
-    auto vesc_model = suchm::can::VescModel{DUMMY_ID};
-    const auto frame = suchm::interface::CanFrame{
-        0xFF << 8 | DUMMY_ID,  // Invalid command ID
-        8,
-        {},
-        true};
-    auto result = vesc_model.get_water_leaked(frame);
-    ASSERT_FALSE(result);
+    ASSERT_TRUE(result);           // Should not fail,
+    ASSERT_FALSE(result.value());  // but return no value
 }
 
 TEST(VescModelTest, VescModelGetWaterLeakedUnmatchedCommandIdTest) {

--- a/test/cpp/mock/can.hpp
+++ b/test/cpp/mock/can.hpp
@@ -4,6 +4,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <rcpputils/tl_expected/expected.hpp>
 
 #include "sinsei_umiusi_control/hardware_model/interface/can.hpp"
@@ -18,8 +19,9 @@ class Can : public sinsei_umiusi_control::hardware_model::interface::Can {
         send_frame, tl::expected<void, std::string>(
                         sinsei_umiusi_control::hardware_model::interface::CanFrame && frame));
     MOCK_METHOD0(
-        recv_frame,
-        tl::expected<sinsei_umiusi_control::hardware_model::interface::CanFrame, std::string>());
+        recv_frame, tl::expected<
+                        std::optional<sinsei_umiusi_control::hardware_model::interface::CanFrame>,
+                        std::string>());
 };
 
 }  // namespace sinsei_umiusi_control::test::mock


### PR DESCRIPTION
自身が送信したフレームに反応してしまう問題に対応したつもりです。

ただ、一部のエラーを握りつぶすことになるので良し悪しはあると思います。

CANの設定の方でループバックを切るなどして解決できるのであればそれで良いとも思います。