### PR TITLE
fix(linux_can): socketを統一し自分が送信したフレームを受信する問題を修正

### DIFF
--- a/include/sinsei_umiusi_control/hardware_model/impl/linux_can.hpp
+++ b/include/sinsei_umiusi_control/hardware_model/impl/linux_can.hpp
@@ -15,8 +15,7 @@ class LinuxCan : public interface::Can {
   private:
     using CanFrame = interface::CanFrame;
 
-    std::optional<FileDescriptor> sock_tx;
-    std::optional<FileDescriptor> sock_rx;
+    std::optional<FileDescriptor> sock;
 
     auto send_linux_can_frame(can_frame && frame) -> tl::expected<void, std::string>;
     auto recv_linux_can_frame() -> tl::expected<can_frame, std::string>;

--- a/src/sinsei_umiusi_control/hardware_model/impl/linux_can.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/impl/linux_can.cpp
@@ -74,7 +74,7 @@ auto suchm::impl::LinuxCan::init(const std::string ifname) -> tl::expected<void,
     std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
     auto res = ::ioctl(this->sock.value(), SIOCGIFINDEX, &ifr);
     if (res < 0) {
-        _close(this->sock);  // Reset the socket descriptor on error
+        this->close();  // Reset the socket descriptor on error
         return tl::make_unexpected(
             "Failed to get interface index: " + std::string(strerror(errno)));
     }
@@ -87,7 +87,7 @@ auto suchm::impl::LinuxCan::init(const std::string ifname) -> tl::expected<void,
     // Bind the socket to the CAN interface
     res = ::bind(this->sock.value(), reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
     if (res < 0) {
-        _close(this->sock);  // Reset the socket descriptor on error
+        this->close();  // Reset the socket descriptor on error
         return tl::make_unexpected("Failed to bind CAN socket: " + std::string(strerror(errno)));
     }
 

--- a/src/sinsei_umiusi_control/hardware_model/impl/linux_can.cpp
+++ b/src/sinsei_umiusi_control/hardware_model/impl/linux_can.cpp
@@ -16,52 +16,6 @@ namespace suchm = sinsei_umiusi_control::hardware_model;
 
 namespace {
 
-auto _close(std::optional<suchm::impl::FileDescriptor> & sock) -> tl::expected<void, std::string> {
-    if (!sock) {
-        return tl::make_unexpected("Socket is not initialized");
-    }
-    auto res = ::close(sock.value());
-    if (res < 0) {
-        return tl::make_unexpected("Failed to close socket: " + std::string(strerror(errno)));
-    }
-    sock.reset();
-    return {};
-}
-
-auto _init(std::optional<suchm::impl::FileDescriptor> & sock, const std::string & ifname)
-    -> tl::expected<void, std::string> {
-    // Create a socket
-    sock = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
-    if (sock < 0) {
-        sock.reset();
-        return tl::make_unexpected("Failed to create CAN socket: " + std::string(strerror(errno)));
-    }
-
-    // Interface request (name -> if_index mapping)
-    struct ifreq ifr {};
-    std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
-    auto res = ::ioctl(sock.value(), SIOCGIFINDEX, &ifr);
-    if (res < 0) {
-        _close(sock);  // Reset the socket descriptor on error
-        return tl::make_unexpected(
-            "Failed to get interface index: " + std::string(strerror(errno)));
-    }
-
-    // Set up the socket address structure
-    sockaddr_can addr{};
-    addr.can_family = AF_CAN;
-    addr.can_ifindex = ifr.ifr_ifindex;
-
-    // Bind the socket to the CAN interface
-    res = ::bind(sock.value(), reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
-    if (res < 0) {
-        _close(sock);  // Reset the socket descriptor on error
-        return tl::make_unexpected("Failed to bind CAN socket: " + std::string(strerror(errno)));
-    }
-
-    return {};
-}
-
 auto _to_linux_can_frame(suchm::interface::CanFrame && frame) -> can_frame {
     can_frame linux_can_frame{};
     if (frame.is_extended) {
@@ -93,28 +47,48 @@ auto _from_linux_can_frame(const can_frame & linux_can_frame) -> suchm::interfac
 
 }  // namespace
 
-suchm::impl::LinuxCan::LinuxCan() : sock_tx(std::nullopt), sock_rx(std::nullopt) {}
+suchm::impl::LinuxCan::LinuxCan() : sock(std::nullopt) {}
 
 auto suchm::impl::LinuxCan::close() -> tl::expected<void, std::string> {
-    auto res_tx = _close(this->sock_tx);
-    auto res_rx = _close(this->sock_rx);
-
-    if (!res_tx || !res_rx) {
-        return tl::make_unexpected(
-            "Failed to close sockets: \n    TX: " + res_tx.error() + "\n    RX: " + res_rx.error());
+    if (!this->sock) {
+        return tl::make_unexpected("Socket is not initialized");
     }
-
+    auto res = ::close(this->sock.value());
+    if (res < 0) {
+        return tl::make_unexpected("Failed to close socket: " + std::string(strerror(errno)));
+    }
+    sock.reset();
     return {};
 }
 
 auto suchm::impl::LinuxCan::init(const std::string ifname) -> tl::expected<void, std::string> {
-    auto res_tx = _init(this->sock_tx, ifname);
-    auto res_rx = _init(this->sock_rx, ifname);
+    // Create a socket
+    this->sock = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (this->sock < 0) {
+        sock.reset();
+        return tl::make_unexpected("Failed to create CAN socket: " + std::string(strerror(errno)));
+    }
 
-    if (!res_tx || !res_rx) {
+    // Interface request (name -> if_index mapping)
+    struct ifreq ifr {};
+    std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
+    auto res = ::ioctl(this->sock.value(), SIOCGIFINDEX, &ifr);
+    if (res < 0) {
+        _close(this->sock);  // Reset the socket descriptor on error
         return tl::make_unexpected(
-            "Failed to initialize sockets: \n    TX: " + res_tx.error() +
-            "\n    RX: " + res_rx.error());
+            "Failed to get interface index: " + std::string(strerror(errno)));
+    }
+
+    // Set up the socket address structure
+    sockaddr_can addr{};
+    addr.can_family = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+
+    // Bind the socket to the CAN interface
+    res = ::bind(this->sock.value(), reinterpret_cast<sockaddr *>(&addr), sizeof(addr));
+    if (res < 0) {
+        _close(this->sock);  // Reset the socket descriptor on error
+        return tl::make_unexpected("Failed to bind CAN socket: " + std::string(strerror(errno)));
     }
 
     return {};
@@ -122,7 +96,7 @@ auto suchm::impl::LinuxCan::init(const std::string ifname) -> tl::expected<void,
 
 auto suchm::impl::LinuxCan::send_linux_can_frame(can_frame && frame)
     -> tl::expected<void, std::string> {
-    if (!this->sock_tx) {
+    if (!this->sock) {
         return tl::make_unexpected("CAN socket is not initialized");
     }
 
@@ -132,7 +106,7 @@ auto suchm::impl::LinuxCan::send_linux_can_frame(can_frame && frame)
 
     // Send the CAN frame
     const auto bytes_to_write = sizeof(frame);
-    const auto bytes_written = ::write(this->sock_tx.value(), &frame, bytes_to_write);
+    const auto bytes_written = ::write(this->sock.value(), &frame, bytes_to_write);
     if (bytes_written < 0) {
         return tl::make_unexpected("Failed to write CAN frame: " + std::string(strerror(errno)));
     }
@@ -147,13 +121,13 @@ auto suchm::impl::LinuxCan::send_linux_can_frame(can_frame && frame)
 }
 
 auto suchm::impl::LinuxCan::recv_linux_can_frame() -> tl::expected<can_frame, std::string> {
-    if (!this->sock_rx) {
+    if (!this->sock) {
         return tl::make_unexpected("CAN socket is not initialized");
     }
 
     fd_set read_fds;
-    FD_ZERO(&read_fds);                        // Clear the set
-    FD_SET(this->sock_rx.value(), &read_fds);  // Add the socket to the set
+    FD_ZERO(&read_fds);                     // Clear the set
+    FD_SET(this->sock.value(), &read_fds);  // Add the socket to the set
 
     // Set a timeout for select (5 ms)
     constexpr int TIMEOUT_MS = 5;
@@ -163,7 +137,7 @@ auto suchm::impl::LinuxCan::recv_linux_can_frame() -> tl::expected<can_frame, st
     };
 
     // Wait for data to be available on the socket
-    const auto nfds = this->sock_rx.value() + 1;  // highest file descriptor + 1
+    const auto nfds = this->sock.value() + 1;  // highest file descriptor + 1
     auto res = ::select(nfds, &read_fds, nullptr, nullptr, &timeout);
     if (res < 0) {
         return tl::make_unexpected("select() failed: " + std::string(strerror(errno)));
@@ -174,7 +148,7 @@ auto suchm::impl::LinuxCan::recv_linux_can_frame() -> tl::expected<can_frame, st
     // Read the CAN frame from the socket
     struct can_frame frame {};
     const auto bytes_to_read = sizeof(frame);
-    const auto bytes_read = ::read(this->sock_rx.value(), &frame, bytes_to_read);
+    const auto bytes_read = ::read(this->sock.value(), &frame, bytes_to_read);
     if (bytes_read < 0) {
         return tl::make_unexpected("read() failed: " + std::string(strerror(errno)));
     }


### PR DESCRIPTION
自分が送信したフレームを受信してしまっていた原因は、ソケットを送受信で分けていたことだったようです。

`setsockopt`を試そうと思って[Linuxカーネルのドキュメント](https://docs.kernel.org/networking/can.html#raw-socket-option-can-raw-loopback)の`CAN_RAW_LOOPBACK`や`CAN_RAW_RECV_OWN_MSGS`の部分を読んでいたら、ソケットが関係あることに気づきました…。

実機で正常にlaunchできエラーも出なくなったことを確認済みです。