### PR TITLE
chore: update_rateを100Hzに変更

### DIFF
--- a/params/controllers.yaml
+++ b/params/controllers.yaml
@@ -1,7 +1,7 @@
 /**:
   controller_manager:
     ros__parameters:
-      update_rate: 300 # Hz
+      update_rate: 100 # Hz
 
   gate_controller:
     ros__parameters:


### PR DESCRIPTION
ラズパイに負荷がかかっていても収まる範囲だったため