### PR TITLE
fix(tasks): local_setupではなくsetupを使用するよう変更

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,7 @@
       "dependsOn": [
         "colcon: build"
       ],
-      "command": "ROOT_DIR=$(dirname $(dirname ${workspaceFolder})) && cd $ROOT_DIR && source install/local_setup.bash && ros2 launch sinsei_umiusi_control main.yaml"
+      "command": "ROOT_DIR=$(dirname $(dirname ${workspaceFolder})) && cd $ROOT_DIR && source install/setup.bash && ros2 launch sinsei_umiusi_control main.yaml"
     }
   ]
 }


### PR DESCRIPTION
ROS2のsetupが済んでいない環境ではこっちを使う必要があるっぽい