### PR TITLE
docs(readme): mermaidのバージョンアップで崩れた箇所を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,18 @@ flowchart LR
     classDef physicalEdge stroke:#4a9df5,stroke-width:3px,color:#4a9df5;
 
     subgraph ROS["ROS Topics"]
-        direction TB
         CMD["cmd/(indicator_led, main_power, led_tape, headlights)_output<br/>cmd/thruster_runnable_all<br/>cmd/target"]
         MANUAL["cmd/direct/thruster_controller/output_*<br/>cmd/direct/thruster_controller/output_all"]
         STATE["state/(imu, imu_temperature, main_power_enabled, thruster_state_all)<br/>state/(low_power_circuit_info, high_power_circuit_info)"]
     end
 
     subgraph CTRL["Controllers"]
-        direction TB
         GATE["GateController"]
         ATT["AttitudeController"]
         THR["ThrusterController x4"]
     end
 
     subgraph HWC["Hardware Components"]
-        direction TB
         LEDC["Indicator LED<br/>(System)"]
         CANC["CAN<br/>(System)"]
         IMUC["IMU<br/>(Sensor)"]
@@ -39,7 +36,6 @@ flowchart LR
     end
 
     subgraph HW["Hardwares"]
-        direction TB
         LED["Indicator LED"]
         MCP["CAN Controller<br/>(MCP2515)"]
         VESC["VESC Boards x4<br/>+ Power Board"]


### PR DESCRIPTION
数日前に出たMermaid v11.16.0では`subgraph`に`direction TB`を指定すると表示が変わってしまうらしく、GitHub上でレイアウトが崩れていたので修正しました

## 修正前

```mermaid
flowchart LR
    classDef topics fill:#ffe3f2,stroke:#d84f9b,color:#222;
    classDef controller fill:#fff0df,stroke:#ff9838,color:#222;
    classDef hwc fill:#e8f2ff,stroke:#4a9df5,color:#222;
    classDef hw fill:#e5faf7,stroke:#57cfc0,color:#222;
    classDef state fill:#eaf8ea,stroke:#62b36f,color:#222;
    classDef topicEdge stroke:#d84f9b,stroke-width:3px,color:#d84f9b;
    classDef commandEdge stroke:#7a5af8,stroke-width:3px,color:#7a5af8;
    classDef stateEdge stroke:#62b36f,stroke-width:3px,color:#62b36f;
    classDef physicalEdge stroke:#4a9df5,stroke-width:3px,color:#4a9df5;

    subgraph ROS["ROS Topics"]
        direction TB
        CMD["cmd/(indicator_led, main_power, led_tape, headlights)_output<br/>cmd/thruster_runnable_all<br/>cmd/target"]
        MANUAL["cmd/direct/thruster_controller/output_*<br/>cmd/direct/thruster_controller/output_all"]
        STATE["state/(imu, imu_temperature, main_power_enabled, thruster_state_all)<br/>state/(low_power_circuit_info, high_power_circuit_info)"]
    end

    subgraph CTRL["Controllers"]
        direction TB
        GATE["GateController"]
        ATT["AttitudeController"]
        THR["ThrusterController x4"]
    end

    subgraph HWC["Hardware Components"]
        direction TB
        LEDC["Indicator LED<br/>(System)"]
        CANC["CAN<br/>(System)"]
        IMUC["IMU<br/>(Sensor)"]
        HLC["Headlights<br/>(System)"]
    end

    subgraph HW["Hardwares"]
        direction TB
        LED["Indicator LED"]
        MCP["CAN Controller<br/>(MCP2515)"]
        VESC["VESC Boards x4<br/>+ Power Board"]
        BNO["IMU<br/>(BNO055)"]
        HL["High Beam<br/>Low Beam<br/>IR"]
    end

    CMD topic_inputs@--> GATE
    GATE topic_outputs@--> STATE

    GATE gate_to_attitude@-- "attitude_controller/target_(orientation, velocity).*" --> ATT
    ATT attitude_to_gate@-- "attitude_controller/imu/(quaternion, acceleration, angular_velocity).*<br/>attitude_controller/thruster_controller_*/thruster/esc/rpm" --> GATE

    GATE gate_to_thruster@-- "thruster_controller_*/(esc, servo)/runnable" --> THR
    ATT attitude_to_thruster@-- "thruster_controller_*/esc/duty_cycle<br/>thruster_controller_*/servo/angle" --> THR
    MANUAL manual_override@-- "manual override" --> THR
    THR thruster_to_gate@-- "thruster_controller_*/esc/(mode, duty_cycle)<br/>thruster_controller_*/servo/(mode, angle)<br/>thruster_controller_*/thruster/esc/(voltage, water_leaked)" --> GATE

    GATE gate_to_indicator@-- "indicator_led/enabled" --> LEDC
    LEDC indicator_gpio@-- "GPIO" --> LED

    GATE gate_to_can@-- "main_power/enabled<br/>led_tape/color" --> CANC
    THR thruster_to_can@-- "thrusterN/esc/(allowed, duty_cycle)<br/>thrusterN/servo/(allowed, angle)" --> CANC
    CANC can_to_gate@-- "main_power/(battery_voltage, battery_current, temperature, water_leaked)<br/>can/health" --> GATE
    CANC can_to_thruster@-- "thrusterN/esc/(rpm, voltage, water_leaked)" --> THR
    CANC can_spi@-- "SPI" --> MCP
    MCP vesc_can@-- "CAN" --> VESC

    IMUC imu_to_attitude@-- "imu/(quaternion, acceleration, angular_velocity).*" --> ATT
    IMUC imu_to_gate@-- "imu/temperature<br/>imu/health" --> GATE
    IMUC imu_i2c@-- "I2C" --> BNO

    GATE gate_to_headlights@-- "headlights/(high_beam, low_beam, ir)_enabled" --> HLC
    HLC headlights_gpio@-- "GPIO" --> HL

    class topic_inputs,topic_outputs,manual_override topicEdge;
    class gate_to_attitude,gate_to_thruster,attitude_to_thruster,gate_to_indicator,gate_to_can,thruster_to_can,gate_to_headlights commandEdge;
    class attitude_to_gate,thruster_to_gate,can_to_gate,can_to_thruster,imu_to_attitude,imu_to_gate stateEdge;
    class indicator_gpio,can_spi,vesc_can,imu_i2c,headlights_gpio physicalEdge;

    class CMD,MANUAL topics;
    class STATE state;
    class GATE,ATT,THR controller;
    class LEDC,CANC,IMUC,HLC hwc;
    class LED,MCP,VESC,BNO,HL hw;
```

## 修正後

```mermaid
flowchart LR
    classDef topics fill:#ffe3f2,stroke:#d84f9b,color:#222;
    classDef controller fill:#fff0df,stroke:#ff9838,color:#222;
    classDef hwc fill:#e8f2ff,stroke:#4a9df5,color:#222;
    classDef hw fill:#e5faf7,stroke:#57cfc0,color:#222;
    classDef state fill:#eaf8ea,stroke:#62b36f,color:#222;
    classDef topicEdge stroke:#d84f9b,stroke-width:3px,color:#d84f9b;
    classDef commandEdge stroke:#7a5af8,stroke-width:3px,color:#7a5af8;
    classDef stateEdge stroke:#62b36f,stroke-width:3px,color:#62b36f;
    classDef physicalEdge stroke:#4a9df5,stroke-width:3px,color:#4a9df5;

    subgraph ROS["ROS Topics"]
        CMD["cmd/(indicator_led, main_power, led_tape, headlights)_output<br/>cmd/thruster_runnable_all<br/>cmd/target"]
        MANUAL["cmd/direct/thruster_controller/output_*<br/>cmd/direct/thruster_controller/output_all"]
        STATE["state/(imu, imu_temperature, main_power_enabled, thruster_state_all)<br/>state/(low_power_circuit_info, high_power_circuit_info)"]
    end

    subgraph CTRL["Controllers"]
        GATE["GateController"]
        ATT["AttitudeController"]
        THR["ThrusterController x4"]
    end

    subgraph HWC["Hardware Components"]
        LEDC["Indicator LED<br/>(System)"]
        CANC["CAN<br/>(System)"]
        IMUC["IMU<br/>(Sensor)"]
        HLC["Headlights<br/>(System)"]
    end

    subgraph HW["Hardwares"]
        LED["Indicator LED"]
        MCP["CAN Controller<br/>(MCP2515)"]
        VESC["VESC Boards x4<br/>+ Power Board"]
        BNO["IMU<br/>(BNO055)"]
        HL["High Beam<br/>Low Beam<br/>IR"]
    end

    CMD topic_inputs@--> GATE
    GATE topic_outputs@--> STATE

    GATE gate_to_attitude@-- "attitude_controller/target_(orientation, velocity).*" --> ATT
    ATT attitude_to_gate@-- "attitude_controller/imu/(quaternion, acceleration, angular_velocity).*<br/>attitude_controller/thruster_controller_*/thruster/esc/rpm" --> GATE

    GATE gate_to_thruster@-- "thruster_controller_*/(esc, servo)/runnable" --> THR
    ATT attitude_to_thruster@-- "thruster_controller_*/esc/duty_cycle<br/>thruster_controller_*/servo/angle" --> THR
    MANUAL manual_override@-- "manual override" --> THR
    THR thruster_to_gate@-- "thruster_controller_*/esc/(mode, duty_cycle)<br/>thruster_controller_*/servo/(mode, angle)<br/>thruster_controller_*/thruster/esc/(voltage, water_leaked)" --> GATE

    GATE gate_to_indicator@-- "indicator_led/enabled" --> LEDC
    LEDC indicator_gpio@-- "GPIO" --> LED

    GATE gate_to_can@-- "main_power/enabled<br/>led_tape/color" --> CANC
    THR thruster_to_can@-- "thrusterN/esc/(allowed, duty_cycle)<br/>thrusterN/servo/(allowed, angle)" --> CANC
    CANC can_to_gate@-- "main_power/(battery_voltage, battery_current, temperature, water_leaked)<br/>can/health" --> GATE
    CANC can_to_thruster@-- "thrusterN/esc/(rpm, voltage, water_leaked)" --> THR
    CANC can_spi@-- "SPI" --> MCP
    MCP vesc_can@-- "CAN" --> VESC

    IMUC imu_to_attitude@-- "imu/(quaternion, acceleration, angular_velocity).*" --> ATT
    IMUC imu_to_gate@-- "imu/temperature<br/>imu/health" --> GATE
    IMUC imu_i2c@-- "I2C" --> BNO

    GATE gate_to_headlights@-- "headlights/(high_beam, low_beam, ir)_enabled" --> HLC
    HLC headlights_gpio@-- "GPIO" --> HL

    class topic_inputs,topic_outputs,manual_override topicEdge;
    class gate_to_attitude,gate_to_thruster,attitude_to_thruster,gate_to_indicator,gate_to_can,thruster_to_can,gate_to_headlights commandEdge;
    class attitude_to_gate,thruster_to_gate,can_to_gate,can_to_thruster,imu_to_attitude,imu_to_gate stateEdge;
    class indicator_gpio,can_spi,vesc_can,imu_i2c,headlights_gpio physicalEdge;

    class CMD,MANUAL topics;
    class STATE state;
    class GATE,ATT,THR controller;
    class LEDC,CANC,IMUC,HLC hwc;
    class LED,MCP,VESC,BNO,HL hw;
```