### PR TITLE
Fix/ff thrust sign bug

### DIFF
--- a/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
+++ b/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
@@ -24,15 +24,12 @@ class FeedForward : public AttitudeController::Logic {
     }
 
     static auto sign(const double & x, const double & y) -> double {
-        // π/2 < φ < 3π/2 (left half-plane) -> negative: a ±90° servo can only aim into the right
-        // half-plane, so left-half forces are produced by reversing the ESC.
-        // std::atan2 returns (-π, π]; wrap negatives into [0, 2π) first, else the third quadrant
-        // (x<0, y<0) is missed and wrongly returns +1.
+        // π/2 < φ < 3π/2 -> negative
         constexpr auto half_pi = boost::math::constants::half_pi<double>();
         constexpr auto two_pi = boost::math::constants::two_pi<double>();
         auto phi = std::atan2(y, x);
         if (phi < 0.0) {
-            phi += two_pi;
+            phi += two_pi;  // (-π, π] -> [0, 2π)
         }
         return (phi > half_pi && phi < 3.0 * half_pi) ? -1.0 : 1.0;
     }

--- a/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
+++ b/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
@@ -24,9 +24,16 @@ class FeedForward : public AttitudeController::Logic {
     }
 
     static auto sign(const double & x, const double & y) -> double {
-        // π/2 < φ < 3π/2 -> negative
+        // π/2 < φ < 3π/2 (left half-plane) -> negative: a ±90° servo can only aim into the right
+        // half-plane, so left-half forces are produced by reversing the ESC.
+        // std::atan2 returns (-π, π]; wrap negatives into [0, 2π) first, else the third quadrant
+        // (x<0, y<0) is missed and wrongly returns +1.
         constexpr auto half_pi = boost::math::constants::half_pi<double>();
-        const auto phi = std::atan2(y, x);
+        constexpr auto two_pi = boost::math::constants::two_pi<double>();
+        auto phi = std::atan2(y, x);
+        if (phi < 0.0) {
+            phi += two_pi;
+        }
         return (phi > half_pi && phi < 3.0 * half_pi) ? -1.0 : 1.0;
     }
 

--- a/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
+++ b/include/sinsei_umiusi_control/controller/logic/attitude/feed_forward.hpp
@@ -23,16 +23,7 @@ class FeedForward : public AttitudeController::Logic {
         return std::sqrt(x * x + y * y);
     }
 
-    static auto sign(const double & x, const double & y) -> double {
-        // π/2 < φ < 3π/2 -> negative
-        constexpr auto half_pi = boost::math::constants::half_pi<double>();
-        constexpr auto two_pi = boost::math::constants::two_pi<double>();
-        auto phi = std::atan2(y, x);
-        if (phi < 0.0) {
-            phi += two_pi;  // (-π, π] -> [0, 2π)
-        }
-        return (phi > half_pi && phi < 3.0 * half_pi) ? -1.0 : 1.0;
-    }
+    static auto sign(const double & x) -> double { return x < 0.0 ? -1.0 : 1.0; }
 
   public:
     auto control_mode() const -> logic::ControlMode override {
@@ -84,7 +75,7 @@ class FeedForward : public AttitudeController::Logic {
             sinsei_umiusi_control::cmd::thruster::servo::Angle{atan_or_zero(y[6], y[7])},
         };
         const auto thrust_sgns = std::array<double, 4>{
-            sign(y[0], y[1]), sign(y[2], y[3]), sign(y[4], y[5]), sign(y[6], y[7])};
+            sign(y[0]), sign(y[2]), sign(y[4]), sign(y[6])};
         const auto thrust_abss = std::array<double, 4>{
             magnitude(y[0], y[1]), magnitude(y[2], y[3]), magnitude(y[4], y[5]),
             magnitude(y[6], y[7])};


### PR DESCRIPTION
https://cpprefjp.github.io/reference/cmath/atan2.html

atan2の定義域は[-pi,pi]なので、第三象限に推力が向いている際に　-pi < fai < -pi/2 となり本来-1になるべき返り値が正となってしまうバグが存在した

atan2で計算した値に2piを足すことで正しく出力されるようにした。

- [x] ビルドが通った
- [x] 出力が正しく出ることを確認した